### PR TITLE
Add test for access CPOs

### DIFF
--- a/gcc/const_iterator.pass.cpp
+++ b/gcc/const_iterator.pass.cpp
@@ -39,17 +39,7 @@ namespace xranges = rxx::ranges;
 
 template <class Iter, bool Const>
 void test01() {
-    if constexpr (std::is_pointer_v<Iter>) {
-        static_assert(std::same_as<rxx::const_iterator<Iter>,
-            std::remove_pointer_t<Iter> const*>);
-        static_assert(std::same_as<rxx::const_sentinel<Iter>,
-            std::remove_pointer_t<Iter> const*>);
-    } else if constexpr (requires { typename Iter::const_iterator_for; }) {
-        static_assert(std::same_as<rxx::const_iterator<Iter>,
-            typename Iter::const_iterator_for>);
-        static_assert(std::same_as<rxx::const_sentinel<Iter>,
-            typename Iter::const_iterator_for>);
-    } else if constexpr (Const) {
+    if constexpr (Const) {
         static_assert(std::same_as<rxx::const_iterator<Iter>, Iter>);
         static_assert(std::same_as<rxx::const_sentinel<Iter>, Iter>);
         static_assert(std::same_as<rxx::iter_const_reference_t<Iter>,
@@ -75,35 +65,7 @@ void test01() {
 
 template <class Range, bool Const>
 void test02() {
-    if constexpr (std::is_pointer_v<xranges::iterator_t<Range>>) {
-        using Iter = xranges::iterator_t<Range>;
-        using ConstPtr =
-            std::remove_pointer_t<xranges::iterator_t<Range>> const*;
-
-        static_assert(std::same_as<xranges::const_iterator_t<Range>, ConstPtr>);
-        if constexpr (xranges::common_range<Range>) {
-            static_assert(
-                std::same_as<xranges::const_sentinel_t<Range>, ConstPtr>);
-        }
-        if constexpr (std::is_const_v<std::remove_reference_t<
-                          std::iter_reference_t<Iter>>>) {
-            static_assert(std::same_as<Iter, ConstPtr>);
-        } else {
-            using Value = std::remove_reference_t<std::iter_reference_t<Iter>>;
-            static_assert(
-                std::same_as<std::add_pointer_t<Value const>, ConstPtr>);
-        }
-    } else if constexpr (requires {
-                             typename xranges::iterator_t<
-                                 Range>::const_iterator_for;
-                         }) {
-        using Iter = typename xranges::iterator_t<Range>::const_iterator_for;
-        static_assert(std::same_as<xranges::const_iterator_t<Range>, Iter>);
-        if constexpr (xranges::common_range<Range>) {
-            static_assert(std::same_as<xranges::const_sentinel_t<Range>, Iter>);
-        }
-        // TODO
-    } else if constexpr (Const) {
+    if constexpr (Const) {
         static_assert(xranges::constant_range<Range>);
         static_assert(std::same_as<xranges::const_iterator_t<Range>,
             xranges::iterator_t<Range>>);

--- a/gcc/const_iterator.pass.cpp
+++ b/gcc/const_iterator.pass.cpp
@@ -39,7 +39,17 @@ namespace xranges = rxx::ranges;
 
 template <class Iter, bool Const>
 void test01() {
-    if constexpr (Const) {
+    if constexpr (std::is_pointer_v<Iter>) {
+        static_assert(std::same_as<rxx::const_iterator<Iter>,
+            std::remove_pointer_t<Iter> const*>);
+        static_assert(std::same_as<rxx::const_sentinel<Iter>,
+            std::remove_pointer_t<Iter> const*>);
+    } else if constexpr (requires { typename Iter::const_iterator_for; }) {
+        static_assert(std::same_as<rxx::const_iterator<Iter>,
+            typename Iter::const_iterator_for>);
+        static_assert(std::same_as<rxx::const_sentinel<Iter>,
+            typename Iter::const_iterator_for>);
+    } else if constexpr (Const) {
         static_assert(std::same_as<rxx::const_iterator<Iter>, Iter>);
         static_assert(std::same_as<rxx::const_sentinel<Iter>, Iter>);
         static_assert(std::same_as<rxx::iter_const_reference_t<Iter>,
@@ -65,7 +75,35 @@ void test01() {
 
 template <class Range, bool Const>
 void test02() {
-    if constexpr (Const) {
+    if constexpr (std::is_pointer_v<xranges::iterator_t<Range>>) {
+        using Iter = xranges::iterator_t<Range>;
+        using ConstPtr =
+            std::remove_pointer_t<xranges::iterator_t<Range>> const*;
+
+        static_assert(std::same_as<xranges::const_iterator_t<Range>, ConstPtr>);
+        if constexpr (xranges::common_range<Range>) {
+            static_assert(
+                std::same_as<xranges::const_sentinel_t<Range>, ConstPtr>);
+        }
+        if constexpr (std::is_const_v<std::remove_reference_t<
+                          std::iter_reference_t<Iter>>>) {
+            static_assert(std::same_as<Iter, ConstPtr>);
+        } else {
+            using Value = std::remove_reference_t<std::iter_reference_t<Iter>>;
+            static_assert(
+                std::same_as<std::add_pointer_t<Value const>, ConstPtr>);
+        }
+    } else if constexpr (requires {
+                             typename xranges::iterator_t<
+                                 Range>::const_iterator_for;
+                         }) {
+        using Iter = typename xranges::iterator_t<Range>::const_iterator_for;
+        static_assert(std::same_as<xranges::const_iterator_t<Range>, Iter>);
+        if constexpr (xranges::common_range<Range>) {
+            static_assert(std::same_as<xranges::const_sentinel_t<Range>, Iter>);
+        }
+        // TODO
+    } else if constexpr (Const) {
         static_assert(xranges::constant_range<Range>);
         static_assert(std::same_as<xranges::const_iterator_t<Range>,
             xranges::iterator_t<Range>>);

--- a/llvm/access/begin.pass.cpp
+++ b/llvm/access/begin.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/begin.pass.cpp
+++ b/llvm/access/begin.pass.cpp
@@ -1,0 +1,411 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::begin
+// std::ranges::cbegin
+
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+#include <cassert>
+#include <ranges>
+#include <utility>
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
+
+using RangeBeginT = decltype(xranges::begin);
+using RangeCBeginT = decltype(xranges::cbegin);
+
+static int globalBuff[8];
+
+static_assert(!std::is_invocable_v<RangeBeginT, int (&&)[10]>);
+static_assert(std::is_invocable_v<RangeBeginT, int (&)[10]>);
+static_assert(!std::is_invocable_v<RangeBeginT, int (&&)[]>);
+static_assert(std::is_invocable_v<RangeBeginT, int (&)[]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, int (&&)[10]>);
+static_assert(std::is_invocable_v<RangeCBeginT, int (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, int (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, int (&)[]>,
+    "No longer allowed in C++23, must be input_range");
+
+struct Incomplete;
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete (&&)[]>);
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete const (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete const (&&)[]>);
+
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete (&&)[10]>);
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete const (&&)[10]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete (&&)[10]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete const (&&)[10]>);
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete (&)[]>);
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete const (&)[]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete (&)[]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete const (&)[]>);
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete (&)[10]>);
+static_assert(!std::is_invocable_v<RangeBeginT, Incomplete const (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Incomplete const (&)[10]>);
+
+struct BeginMember {
+    int x;
+    constexpr int const* begin() const { return &x; }
+};
+
+// Ensure that we can't call with rvalues with borrowing disabled.
+static_assert(std::is_invocable_v<RangeBeginT, BeginMember&>);
+static_assert(!std::is_invocable_v<RangeBeginT, BeginMember&&>);
+static_assert(std::is_invocable_v<RangeBeginT, BeginMember const&>);
+static_assert(!std::is_invocable_v<RangeBeginT, BeginMember const&&>);
+static_assert(!std::is_invocable_v<RangeCBeginT, BeginMember&>,
+    "No longer allowed in C++23, must be input_range");
+static_assert(!std::is_invocable_v<RangeCBeginT, BeginMember&&>);
+static_assert(!std::is_invocable_v<RangeCBeginT, BeginMember const&>,
+    "No longer allowed in C++23, must be input_range");
+static_assert(!std::is_invocable_v<RangeCBeginT, BeginMember const&&>);
+
+constexpr bool testReturnTypes() {
+    {
+        int* x[2];
+        ASSERT_SAME_TYPE(decltype(std::ranges::begin(x)), int**);
+        ASSERT_SAME_TYPE(decltype(std::ranges::cbegin(x)), int* const*);
+    }
+    {
+        int x[2][2];
+        ASSERT_SAME_TYPE(decltype(std::ranges::begin(x)), int(*)[2]);
+        ASSERT_SAME_TYPE(decltype(std::ranges::cbegin(x)), int const(*)[2]);
+    }
+    {
+        struct Different {
+            char*& begin();
+            short*& begin() const;
+        } x;
+        ASSERT_SAME_TYPE(decltype(std::ranges::begin(x)), char*);
+        ASSERT_SAME_TYPE(decltype(std::ranges::cbegin(x)), short*);
+    }
+    return true;
+}
+
+constexpr bool testArray() {
+    int a[2];
+    assert(xranges::begin(a) == a);
+    assert(xranges::cbegin(a) == a);
+
+    int b[2][2];
+    assert(xranges::begin(b) == b);
+    assert(xranges::cbegin(b) == b);
+
+    BeginMember c[2];
+    assert(xranges::begin(c) == c);
+    assert(xranges::cbegin(c) == c);
+
+    return true;
+}
+
+struct BeginMemberReturnsInt {
+    int begin() const;
+};
+static_assert(!std::is_invocable_v<RangeBeginT, BeginMemberReturnsInt const&>);
+
+struct BeginMemberReturnsVoidPtr {
+    void const* begin() const;
+};
+static_assert(
+    !std::is_invocable_v<RangeBeginT, BeginMemberReturnsVoidPtr const&>);
+
+struct EmptyBeginMember {
+    struct iterator {};
+    iterator begin() const;
+};
+static_assert(!std::is_invocable_v<RangeBeginT, EmptyBeginMember const&>);
+
+struct PtrConvertibleBeginMember {
+    struct iterator {
+        operator int*() const;
+    };
+    iterator begin() const;
+};
+static_assert(
+    !std::is_invocable_v<RangeBeginT, PtrConvertibleBeginMember const&>);
+
+struct NonConstBeginMember {
+    int x;
+    constexpr int* begin() { return &x; }
+};
+static_assert(std::is_invocable_v<RangeBeginT, NonConstBeginMember&>);
+static_assert(!std::is_invocable_v<RangeBeginT, NonConstBeginMember const&>);
+static_assert(!std::is_invocable_v<RangeCBeginT, NonConstBeginMember&>);
+static_assert(!std::is_invocable_v<RangeCBeginT, NonConstBeginMember const&>);
+
+struct EnabledBorrowingBeginMember {
+    constexpr int* begin() const { return &globalBuff[0]; }
+    constexpr int* end() const {
+        return globalBuff + std::ranges::size(globalBuff);
+    }
+};
+template <>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<EnabledBorrowingBeginMember> = true;
+
+struct BeginMemberFunction {
+    int x;
+    constexpr int const* begin() const { return &x; }
+    constexpr int const* end() const { return begin() + 1; }
+    friend int* begin(BeginMemberFunction const&);
+};
+
+struct EmptyPtrBeginMember {
+    struct Empty {};
+    Empty x;
+    constexpr Empty const* begin() const { return &x; }
+    constexpr Empty const* end() const { return &x + 1; }
+};
+
+constexpr bool testBeginMember() {
+    BeginMember a;
+    assert(xranges::begin(a) == &a.x);
+    // assert(xranges::cbegin(a) == &a.x);
+    static_assert(!std::is_invocable_v<RangeBeginT, BeginMember&&>);
+    static_assert(!std::is_invocable_v<RangeCBeginT, BeginMember&&>);
+
+    NonConstBeginMember b;
+    assert(xranges::begin(b) == &b.x);
+    static_assert(!std::is_invocable_v<RangeCBeginT, NonConstBeginMember&>);
+
+    EnabledBorrowingBeginMember c;
+    assert(xranges::begin(c) == &globalBuff[0]);
+    // assert(xranges::cbegin(c) == &globalBuff[0]);
+    assert(xranges::begin(std::move(c)) == &globalBuff[0]);
+    assert(xranges::cbegin(std::move(c)) == &globalBuff[0]);
+
+    BeginMemberFunction d;
+    assert(xranges::begin(d) == &d.x);
+    assert(xranges::cbegin(d) == &d.x);
+
+    EmptyPtrBeginMember e;
+    assert(xranges::begin(e) == &e.x);
+    assert(xranges::cbegin(e) == &e.x);
+
+    return true;
+}
+
+struct BeginFunction {
+    int x;
+    friend constexpr int const* begin(BeginFunction const& bf) { return &bf.x; }
+    friend constexpr int const* end(BeginFunction const& bf) {
+        return &bf.x + 1;
+    }
+};
+static_assert(std::is_invocable_v<RangeBeginT, BeginFunction const&>);
+static_assert(!std::is_invocable_v<RangeBeginT, BeginFunction&&>);
+static_assert(std::is_invocable_v<RangeBeginT,
+    BeginFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+static_assert(std::is_invocable_v<RangeCBeginT, BeginFunction const&>);
+static_assert(std::is_invocable_v<RangeCBeginT, BeginFunction&>);
+
+struct BeginFunctionReturnsInt {
+    friend int begin(BeginFunctionReturnsInt const&);
+};
+static_assert(
+    !std::is_invocable_v<RangeBeginT, BeginFunctionReturnsInt const&>);
+
+struct BeginFunctionReturnsVoidPtr {
+    friend void* begin(BeginFunctionReturnsVoidPtr const&);
+};
+static_assert(
+    !std::is_invocable_v<RangeBeginT, BeginFunctionReturnsVoidPtr const&>);
+
+struct BeginFunctionReturnsPtrConvertible {
+    struct iterator {
+        operator int*() const;
+    };
+    friend iterator begin(BeginFunctionReturnsPtrConvertible const&);
+};
+static_assert(!std::is_invocable_v<RangeBeginT,
+              BeginFunctionReturnsPtrConvertible const&>);
+
+struct BeginFunctionByValue {
+    friend constexpr int* begin(BeginFunctionByValue) { return globalBuff + 1; }
+    friend constexpr int* end(BeginFunctionByValue) { return globalBuff + 2; }
+};
+static_assert(!std::is_invocable_v<RangeCBeginT, BeginFunctionByValue>);
+
+struct BeginFunctionEnabledBorrowing {
+    friend constexpr int* begin(BeginFunctionEnabledBorrowing) {
+        return globalBuff + 2;
+    }
+
+    friend constexpr int* end(BeginFunctionEnabledBorrowing) {
+        return globalBuff + 3;
+    }
+};
+template <>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<BeginFunctionEnabledBorrowing> = true;
+
+struct BeginFunctionReturnsEmptyPtr {
+    struct Empty {};
+    Empty x;
+    friend constexpr Empty const* begin(
+        BeginFunctionReturnsEmptyPtr const& bf) {
+        return &bf.x;
+    }
+
+    friend constexpr Empty const* end(BeginFunctionReturnsEmptyPtr const& bf) {
+        return &bf.x + 1;
+    }
+};
+
+struct BeginFunctionWithDataMember {
+    int x;
+    int begin;
+    friend constexpr int const* begin(BeginFunctionWithDataMember const& bf) {
+        return &bf.x;
+    }
+
+    friend constexpr int const* end(BeginFunctionWithDataMember const& bf) {
+        return &bf.x + 1;
+    }
+};
+
+struct BeginFunctionWithPrivateBeginMember {
+    int y;
+    friend constexpr int const* begin(
+        BeginFunctionWithPrivateBeginMember const& bf) {
+        return &bf.y;
+    }
+
+    friend constexpr int const* end(
+        BeginFunctionWithPrivateBeginMember const& bf) {
+        return &bf.y + 1;
+    }
+
+private:
+    int const* begin() const;
+};
+
+constexpr bool testBeginFunction() {
+    BeginFunction a{};
+    BeginFunction const aa{};
+    assert(xranges::begin(a) ==
+        &a.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::cbegin(a) == &a.x);
+    assert(xranges::begin(aa) == &aa.x);
+    assert(xranges::cbegin(aa) == &aa.x);
+
+    BeginFunctionByValue b{};
+    BeginFunctionByValue const bb{};
+    assert(xranges::begin(b) == &globalBuff[1]);
+    assert(xranges::cbegin(b) == &globalBuff[1]);
+    assert(xranges::begin(bb) == &globalBuff[1]);
+    assert(xranges::cbegin(bb) == &globalBuff[1]);
+
+    BeginFunctionEnabledBorrowing c{};
+    BeginFunctionEnabledBorrowing const cc{};
+    assert(xranges::begin(std::move(c)) == &globalBuff[2]);
+    assert(xranges::cbegin(std::move(c)) == &globalBuff[2]);
+    assert(xranges::begin(std::move(cc)) == &globalBuff[2]);
+    assert(xranges::cbegin(std::move(cc)) == &globalBuff[2]);
+
+    BeginFunctionReturnsEmptyPtr d{};
+    BeginFunctionReturnsEmptyPtr const dd{};
+    assert(xranges::begin(d) ==
+        &d.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::cbegin(d) == &d.x);
+    assert(xranges::begin(dd) == &dd.x);
+    assert(xranges::cbegin(dd) == &dd.x);
+
+    BeginFunctionWithDataMember e{};
+    BeginFunctionWithDataMember const ee{};
+    assert(xranges::begin(e) ==
+        &e.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::begin(ee) == &ee.x);
+    assert(xranges::cbegin(e) == &e.x);
+    assert(xranges::cbegin(ee) == &ee.x);
+
+    BeginFunctionWithPrivateBeginMember f{};
+    BeginFunctionWithPrivateBeginMember const ff{};
+    assert(xranges::begin(f) ==
+        &f.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::cbegin(f) == &f.y);
+    assert(xranges::begin(ff) == &ff.y);
+    assert(xranges::cbegin(ff) == &ff.y);
+
+    return true;
+}
+
+ASSERT_NOEXCEPT(xranges::begin(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(xranges::cbegin(std::declval<int (&)[10]>()));
+
+struct NoThrowMemberBegin {
+    ThrowingIterator<int>
+    begin() const noexcept; // auto(t.begin()) doesn't throw
+
+    ThrowingIterator<int> end() const noexcept; // auto(t.begin()) doesn't throw
+} ntmb;
+static_assert(noexcept(xranges::begin(ntmb)));
+static_assert(noexcept(xranges::cbegin(ntmb)));
+
+struct NoThrowADLBegin {
+    friend ThrowingIterator<int> begin(
+        NoThrowADLBegin&) noexcept; // auto(begin(t)) doesn't throw
+    friend ThrowingIterator<int> begin(NoThrowADLBegin const&) noexcept;
+    friend ThrowingIterator<int> end(NoThrowADLBegin&) noexcept;
+    friend ThrowingIterator<int> end(NoThrowADLBegin const&) noexcept;
+} ntab;
+static_assert(noexcept(xranges::begin(ntab)));
+static_assert(noexcept(xranges::cbegin(ntab)));
+
+struct NoThrowMemberBeginReturnsRef {
+    ThrowingIterator<int>& begin() const noexcept; // auto(t.begin()) may throw
+    ThrowingIterator<int>& end() const noexcept;   // auto(t.end()) may throw
+} ntmbrr;
+static_assert(!noexcept(xranges::begin(ntmbrr)));
+static_assert(!noexcept(xranges::cbegin(ntmbrr)));
+
+struct BeginReturnsArrayRef {
+    auto begin() const noexcept -> int (&)[10];
+
+    auto end() const noexcept -> int*;
+} brar;
+static_assert(noexcept(xranges::begin(brar)));
+static_assert(noexcept(xranges::cbegin(brar)));
+
+// Test ADL-proofing.
+struct Incomplete;
+template <class T>
+struct Holder {
+    T t;
+};
+static_assert(!std::is_invocable_v<RangeBeginT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeBeginT, Holder<Incomplete>*&>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeCBeginT, Holder<Incomplete>*&>);
+
+int main(int, char**) {
+    static_assert(testReturnTypes());
+
+    testArray();
+    static_assert(testArray());
+
+    testBeginMember();
+    static_assert(testBeginMember());
+
+    testBeginFunction();
+    static_assert(testBeginFunction());
+
+    return 0;
+}

--- a/llvm/access/begin.pass.cpp
+++ b/llvm/access/begin.pass.cpp
@@ -100,7 +100,8 @@ constexpr bool testReturnTypes() {
         } x;
 
         ASSERT_SAME_TYPE(decltype(xranges::begin(x)), char*);
-        ASSERT_SAME_TYPE(decltype(xranges::cbegin(x)), short const*);
+        ASSERT_SAME_TYPE(
+            decltype(xranges::cbegin(x)), rxx::basic_const_iterator<short*>);
     }
     return true;
 }

--- a/llvm/access/begin.pass.cpp
+++ b/llvm/access/begin.pass.cpp
@@ -83,21 +83,24 @@ static_assert(!std::is_invocable_v<RangeCBeginT, BeginMember const&&>);
 constexpr bool testReturnTypes() {
     {
         int* x[2];
-        ASSERT_SAME_TYPE(decltype(std::ranges::begin(x)), int**);
-        ASSERT_SAME_TYPE(decltype(std::ranges::cbegin(x)), int* const*);
+        ASSERT_SAME_TYPE(decltype(xranges::begin(x)), int**);
+        ASSERT_SAME_TYPE(decltype(xranges::cbegin(x)), int* const*);
     }
     {
         int x[2][2];
-        ASSERT_SAME_TYPE(decltype(std::ranges::begin(x)), int(*)[2]);
-        ASSERT_SAME_TYPE(decltype(std::ranges::cbegin(x)), int const(*)[2]);
+        ASSERT_SAME_TYPE(decltype(xranges::begin(x)), int(*)[2]);
+        ASSERT_SAME_TYPE(decltype(xranges::cbegin(x)), int const(*)[2]);
     }
     {
         struct Different {
             char*& begin();
             short*& begin() const;
+            char*& end();
+            short*& end() const;
         } x;
-        ASSERT_SAME_TYPE(decltype(std::ranges::begin(x)), char*);
-        ASSERT_SAME_TYPE(decltype(std::ranges::cbegin(x)), short*);
+
+        ASSERT_SAME_TYPE(decltype(xranges::begin(x)), char*);
+        ASSERT_SAME_TYPE(decltype(xranges::cbegin(x)), short const*);
     }
     return true;
 }

--- a/llvm/access/begin.sizezero.pass.cpp
+++ b/llvm/access/begin.sizezero.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: msvc
+
+// std::ranges::begin
+// std::ranges::cbegin
+//   Test the fix for https://llvm.org/PR54100
+
+#if RXX_COMPILER_CLANG | RXX_COMPILER_GCC
+
+#  include "../static_asserts.h"
+#  include "../test_iterators.h"
+#  include "rxx/access.h"
+
+#  include <cassert>
+#  include <ranges>
+
+struct A {
+    int m[0];
+};
+static_assert(sizeof(A) == 0); // an extension supported by GCC and Clang
+
+int main(int, char**) {
+    A a[10];
+    std::same_as<A*> auto p = std::ranges::begin(a);
+    assert(p == a);
+    std::same_as<A const*> auto cp = std::ranges::cbegin(a);
+    assert(cp == a);
+
+    return 0;
+}
+
+#endif

--- a/llvm/access/begin.sizezero.pass.cpp
+++ b/llvm/access/begin.sizezero.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -13,14 +16,13 @@
 // std::ranges::cbegin
 //   Test the fix for https://llvm.org/PR54100
 
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+#include <cassert>
+
 #if RXX_COMPILER_CLANG | RXX_COMPILER_GCC
-
-#  include "../static_asserts.h"
-#  include "../test_iterators.h"
-#  include "rxx/access.h"
-
-#  include <cassert>
-#  include <ranges>
 
 struct A {
     int m[0];
@@ -34,6 +36,11 @@ int main(int, char**) {
     std::same_as<A const*> auto cp = std::ranges::cbegin(a);
     assert(cp == a);
 
+    return 0;
+}
+#else
+
+int main() {
     return 0;
 }
 

--- a/llvm/access/begin.verify.cpp
+++ b/llvm/access/begin.verify.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/begin.verify.cpp
+++ b/llvm/access/begin.verify.cpp
@@ -11,7 +11,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::begin
+// rxx::ranges::begin
 
 #include "../static_asserts.h"
 #include "../test_iterators.h"
@@ -30,7 +30,8 @@ static_assert(!xranges::enable_borrowed_range<NonBorrowedRange>);
 // false, `ranges::begin` is ill-formed.
 void test() {
     xranges::begin(NonBorrowedRange());
-    // expected-error-re@-1 {{{{call to deleted function call operator in type
-    // 'const (std::ranges::)?__begin::__fn'}}}} expected-error@-2  {{attempt to
-    // use a deleted function}}
+    // clang-format off
+    // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (rxx::ranges::)?details::begin_t'}}}}
+    // expected-error@-2  {{attempt to use a deleted function}}
+    // clang-format on
 }

--- a/llvm/access/begin.verify.cpp
+++ b/llvm/access/begin.verify.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::begin
+
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
+
+struct NonBorrowedRange {
+    int* begin() const;
+    int* end() const;
+};
+static_assert(!xranges::enable_borrowed_range<NonBorrowedRange>);
+
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is
+// false, `ranges::begin` is ill-formed.
+void test() {
+    xranges::begin(NonBorrowedRange());
+    // expected-error-re@-1 {{{{call to deleted function call operator in type
+    // 'const (std::ranges::)?__begin::__fn'}}}} expected-error@-2  {{attempt to
+    // use a deleted function}}
+}

--- a/llvm/access/data.pass.cpp
+++ b/llvm/access/data.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/data.pass.cpp
+++ b/llvm/access/data.pass.cpp
@@ -1,0 +1,350 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// rxx::ranges::data
+
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+#include <cassert>
+#include <ranges>
+#include <type_traits>
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
+
+using RangeDataT = decltype(xranges::data);
+using RangeCDataT = decltype(xranges::cdata);
+
+static int globalBuff[2];
+
+struct Incomplete;
+
+static_assert(!std::is_invocable_v<RangeDataT, Incomplete[]>);
+static_assert(!std::is_invocable_v<RangeDataT, Incomplete (&&)[2]>);
+static_assert(!std::is_invocable_v<RangeDataT, Incomplete (&&)[2][2]>);
+static_assert(!std::is_invocable_v<RangeDataT, int[1]>);
+static_assert(!std::is_invocable_v<RangeDataT, int (&&)[1]>);
+static_assert(std::is_invocable_v<RangeDataT, int (&)[1]>);
+
+static_assert(!std::is_invocable_v<RangeCDataT, Incomplete[]>);
+static_assert(!std::is_invocable_v<RangeCDataT, Incomplete (&&)[2]>);
+static_assert(!std::is_invocable_v<RangeCDataT, Incomplete (&&)[2][2]>);
+static_assert(!std::is_invocable_v<RangeCDataT, int[1]>);
+static_assert(!std::is_invocable_v<RangeCDataT, int (&&)[1]>);
+static_assert(std::is_invocable_v<RangeCDataT, int (&)[1]>);
+
+struct DataMember {
+    int x;
+    constexpr int const* data() const { return &x; }
+    constexpr int const* begin() const { return &x; }
+    constexpr int const* end() const { return &x + 1; }
+};
+static_assert(std::is_invocable_v<RangeDataT, DataMember&>);
+static_assert(!std::is_invocable_v<RangeDataT, DataMember&&>);
+static_assert(std::is_invocable_v<RangeDataT, DataMember const&>);
+static_assert(!std::is_invocable_v<RangeDataT, DataMember const&&>);
+static_assert(std::is_invocable_v<RangeCDataT, DataMember&>);
+static_assert(!std::is_invocable_v<RangeCDataT, DataMember&&>);
+static_assert(std::is_invocable_v<RangeCDataT, DataMember const&>);
+static_assert(!std::is_invocable_v<RangeCDataT, DataMember const&&>);
+
+constexpr bool testReturnTypes() {
+    {
+        int* x[2];
+        ASSERT_SAME_TYPE(decltype(xranges::data(x)), int**);
+        ASSERT_SAME_TYPE(decltype(xranges::cdata(x)), int* const*);
+    }
+    {
+        int x[2][2];
+        ASSERT_SAME_TYPE(decltype(xranges::data(x)), int(*)[2]);
+        ASSERT_SAME_TYPE(decltype(xranges::cdata(x)), int const(*)[2]);
+    }
+    RXX_DISABLE_WARNING_PUSH()
+#if RXX_COMPILER_CLANG | RXX_COMPILER_GCC
+    RXX_DISABLE_WARNING("-Wundefined-inline")
+#endif
+    {
+        struct D {
+            char*& data();
+            short*& data() const;
+            constexpr char* begin();
+            constexpr char* end();
+            constexpr short const* begin() const;
+            constexpr short const* end() const;
+        };
+        ASSERT_SAME_TYPE(
+            decltype(xranges::data(std::declval<D const&>())), short*);
+        static_assert(!std::is_invocable_v<RangeDataT, D const&&>);
+        ASSERT_SAME_TYPE(
+            decltype(xranges::cdata(std::declval<D&>())), char const*);
+        static_assert(!std::is_invocable_v<RangeCDataT, D&&>);
+        ASSERT_SAME_TYPE(
+            decltype(xranges::cdata(std::declval<D const&>())), short const*);
+        static_assert(!std::is_invocable_v<RangeCDataT, D const&&>);
+    }
+    {
+        struct NC {
+            char* begin() const;
+            char* end() const;
+            int* data();
+        };
+        static_assert(!xranges::contiguous_range<NC>);
+        static_assert(xranges::contiguous_range<const NC>);
+        ASSERT_SAME_TYPE(decltype(xranges::data(std::declval<NC&>())), int*);
+        static_assert(!std::is_invocable_v<RangeDataT, NC&&>);
+        ASSERT_SAME_TYPE(
+            decltype(xranges::data(std::declval<const NC&>())), char*);
+        static_assert(!std::is_invocable_v<RangeDataT, const NC&&>);
+        ASSERT_SAME_TYPE(
+            decltype(xranges::cdata(std::declval<NC&>())), char const*);
+        static_assert(!std::is_invocable_v<RangeCDataT, NC&&>);
+        ASSERT_SAME_TYPE(
+            decltype(xranges::cdata(std::declval<const NC&>())), char const*);
+        static_assert(!std::is_invocable_v<RangeCDataT, const NC&&>);
+    }
+    RXX_DISABLE_WARNING_POP()
+    return true;
+}
+
+struct VoidDataMember {
+    void* data() const;
+};
+static_assert(!std::is_invocable_v<RangeDataT, VoidDataMember const&>);
+static_assert(!std::is_invocable_v<RangeCDataT, VoidDataMember const&>);
+
+struct Empty {};
+struct EmptyDataMember {
+    Empty data() const;
+};
+static_assert(!std::is_invocable_v<RangeDataT, EmptyDataMember const&>);
+static_assert(!std::is_invocable_v<RangeCDataT, EmptyDataMember const&>);
+
+struct PtrConvertibleDataMember {
+    struct Ptr {
+        operator int*() const;
+    };
+    Ptr data() const;
+};
+static_assert(
+    !std::is_invocable_v<RangeDataT, PtrConvertibleDataMember const&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, PtrConvertibleDataMember const&>);
+
+struct NonConstDataMember {
+    int x;
+    constexpr int* data() { return &x; }
+};
+
+struct EnabledBorrowingDataMember {
+    constexpr int* data() { return &globalBuff[0]; }
+};
+template <>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<EnabledBorrowingDataMember> = true;
+
+struct DataMemberAndBegin {
+    int x;
+    constexpr int const* data() const { return &x; }
+    int const* begin() const;
+    int const* end() const;
+};
+
+constexpr bool testDataMember() {
+    DataMember a;
+    assert(xranges::data(a) == &a.x);
+    assert(xranges::cdata(a) == &a.x);
+
+    NonConstDataMember b;
+    assert(xranges::data(b) == &b.x);
+    static_assert(!std::is_invocable_v<RangeCDataT, decltype((b))>);
+
+    EnabledBorrowingDataMember c;
+    assert(xranges::data(std::move(c)) == &globalBuff[0]);
+    static_assert(!std::is_invocable_v<RangeCDataT, decltype(std::move(c))>);
+
+    DataMemberAndBegin d;
+    assert(xranges::data(d) == &d.x);
+    assert(xranges::cdata(d) == &d.x);
+
+    return true;
+}
+
+using ContiguousIter = contiguous_iterator<int const*>;
+
+struct BeginMemberContiguousIterator {
+    int buff[8];
+
+    constexpr ContiguousIter begin() const { return ContiguousIter(buff); }
+    constexpr ContiguousIter end() const { return ContiguousIter(buff + 8); }
+};
+static_assert(std::is_invocable_v<RangeDataT, BeginMemberContiguousIterator&>);
+static_assert(
+    !std::is_invocable_v<RangeDataT, BeginMemberContiguousIterator&&>);
+static_assert(
+    std::is_invocable_v<RangeDataT, BeginMemberContiguousIterator const&>);
+static_assert(
+    !std::is_invocable_v<RangeDataT, BeginMemberContiguousIterator const&&>);
+static_assert(std::is_invocable_v<RangeCDataT, BeginMemberContiguousIterator&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginMemberContiguousIterator&&>);
+static_assert(
+    std::is_invocable_v<RangeCDataT, BeginMemberContiguousIterator const&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginMemberContiguousIterator const&&>);
+
+struct BeginMemberRandomAccess {
+    int buff[8];
+
+    random_access_iterator<int const*> begin() const;
+};
+static_assert(!std::is_invocable_v<RangeDataT, BeginMemberRandomAccess&>);
+static_assert(!std::is_invocable_v<RangeDataT, BeginMemberRandomAccess&&>);
+static_assert(!std::is_invocable_v<RangeDataT, BeginMemberRandomAccess const&>);
+static_assert(
+    !std::is_invocable_v<RangeDataT, BeginMemberRandomAccess const&&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginMemberRandomAccess&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginMemberRandomAccess&&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginMemberRandomAccess const&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginMemberRandomAccess const&&>);
+
+struct BeginFriendContiguousIterator {
+    int buff[8];
+
+    friend constexpr ContiguousIter begin(
+        BeginFriendContiguousIterator const& iter) {
+        return ContiguousIter(iter.buff);
+    }
+
+    friend constexpr ContiguousIter end(
+        BeginFriendContiguousIterator const& iter) {
+        return ContiguousIter(iter.buff + 8);
+    }
+};
+static_assert(std::is_invocable_v<RangeDataT, BeginMemberContiguousIterator&>);
+static_assert(
+    !std::is_invocable_v<RangeDataT, BeginMemberContiguousIterator&&>);
+static_assert(
+    std::is_invocable_v<RangeDataT, BeginMemberContiguousIterator const&>);
+static_assert(
+    !std::is_invocable_v<RangeDataT, BeginMemberContiguousIterator const&&>);
+static_assert(std::is_invocable_v<RangeCDataT, BeginMemberContiguousIterator&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginMemberContiguousIterator&&>);
+static_assert(
+    std::is_invocable_v<RangeCDataT, BeginMemberContiguousIterator const&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginMemberContiguousIterator const&&>);
+
+struct BeginFriendRandomAccess {
+    friend random_access_iterator<int const*> begin(
+        BeginFriendRandomAccess const iter);
+};
+static_assert(!std::is_invocable_v<RangeDataT, BeginFriendRandomAccess&>);
+static_assert(!std::is_invocable_v<RangeDataT, BeginFriendRandomAccess&&>);
+static_assert(!std::is_invocable_v<RangeDataT, BeginFriendRandomAccess const&>);
+static_assert(
+    !std::is_invocable_v<RangeDataT, BeginFriendRandomAccess const&&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginFriendRandomAccess&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginFriendRandomAccess&&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginFriendRandomAccess const&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginFriendRandomAccess const&&>);
+
+struct BeginMemberRvalue {
+    int buff[8];
+
+    ContiguousIter begin() &&;
+};
+static_assert(!std::is_invocable_v<RangeDataT, BeginMemberRvalue&>);
+static_assert(!std::is_invocable_v<RangeDataT, BeginMemberRvalue&&>);
+static_assert(!std::is_invocable_v<RangeDataT, BeginMemberRvalue const&>);
+static_assert(!std::is_invocable_v<RangeDataT, BeginMemberRvalue const&&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginMemberRvalue&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginMemberRvalue&&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginMemberRvalue const&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginMemberRvalue const&&>);
+
+struct BeginMemberBorrowingEnabled {
+    constexpr contiguous_iterator<int*> begin() {
+        return contiguous_iterator<int*>{&globalBuff[1]};
+    }
+};
+template <>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<BeginMemberBorrowingEnabled> = true;
+static_assert(std::is_invocable_v<RangeDataT, BeginMemberBorrowingEnabled&>);
+static_assert(std::is_invocable_v<RangeDataT, BeginMemberBorrowingEnabled&&>);
+static_assert(
+    !std::is_invocable_v<RangeDataT, BeginMemberBorrowingEnabled const&>);
+static_assert(
+    !std::is_invocable_v<RangeDataT, BeginMemberBorrowingEnabled const&&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginMemberBorrowingEnabled&>);
+static_assert(!std::is_invocable_v<RangeCDataT, BeginMemberBorrowingEnabled&&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginMemberBorrowingEnabled const&>);
+static_assert(
+    !std::is_invocable_v<RangeCDataT, BeginMemberBorrowingEnabled const&&>);
+
+constexpr bool testViaRangesBegin() {
+    int arr[2];
+    assert(xranges::data(arr) == arr + 0);
+    assert(xranges::cdata(arr) == arr + 0);
+
+    BeginMemberContiguousIterator a;
+    assert(xranges::data(a) == a.buff);
+    assert(xranges::cdata(a) == a.buff);
+
+    BeginFriendContiguousIterator const b{};
+    assert(xranges::data(b) == b.buff);
+    assert(xranges::cdata(b) == b.buff);
+
+    BeginMemberBorrowingEnabled c;
+    assert(xranges::data(std::move(c)) == &globalBuff[1]);
+    static_assert(!std::is_invocable_v<RangeCDataT, decltype(std::move(c))>);
+
+    return true;
+}
+
+// Test ADL-proofing.
+struct Incomplete;
+template <class T>
+struct Holder {
+    T t;
+};
+static_assert(!std::is_invocable_v<RangeDataT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeDataT, Holder<Incomplete>*&>);
+static_assert(!std::is_invocable_v<RangeCDataT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeCDataT, Holder<Incomplete>*&>);
+
+struct RandomButNotContiguous {
+    random_access_iterator<int*> begin() const;
+    random_access_iterator<int*> end() const;
+};
+static_assert(!std::is_invocable_v<RangeDataT, RandomButNotContiguous>);
+static_assert(!std::is_invocable_v<RangeDataT, RandomButNotContiguous&>);
+static_assert(!std::is_invocable_v<RangeCDataT, RandomButNotContiguous>);
+static_assert(!std::is_invocable_v<RangeCDataT, RandomButNotContiguous&>);
+
+int main(int, char**) {
+    static_assert(testReturnTypes());
+
+    testDataMember();
+    static_assert(testDataMember());
+
+    testViaRangesBegin();
+    static_assert(testViaRangesBegin());
+
+    return 0;
+}

--- a/llvm/access/data.verify.cpp
+++ b/llvm/access/data.verify.cpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::data
+
+#include <ranges>
+
+struct NonBorrowedRange {
+  int* begin() const;
+  int* end() const;
+};
+static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
+
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::data` is ill-formed.
+void test() {
+  std::ranges::data(NonBorrowedRange());
+  // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?__data::__fn'}}}}
+}

--- a/llvm/access/data.verify.cpp
+++ b/llvm/access/data.verify.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/data.verify.cpp
+++ b/llvm/access/data.verify.cpp
@@ -11,18 +11,26 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::data
+// rxx::ranges::data
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
 
 struct NonBorrowedRange {
-  int* begin() const;
-  int* end() const;
+    int* begin() const;
+    int* end() const;
 };
 static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
 
-// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::data` is ill-formed.
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is
+// false, `ranges::data` is ill-formed.
 void test() {
-  std::ranges::data(NonBorrowedRange());
-  // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?__data::__fn'}}}}
+    xranges::data(NonBorrowedRange());
+    // clang-format off
+    // expected-error-re@-1 {{{{no matching function for call to object of type 'const (rxx::ranges::)?details::data_t'}}}}
+    // clang-format on
 }

--- a/llvm/access/empty.pass.cpp
+++ b/llvm/access/empty.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/empty.pass.cpp
+++ b/llvm/access/empty.pass.cpp
@@ -1,0 +1,194 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// xranges::empty
+
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+#include <cassert>
+#include <ranges>
+#include <utility>
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
+
+using RangeEmptyT = decltype(xranges::empty);
+
+static_assert(!std::is_invocable_v<RangeEmptyT, int[]>);
+static_assert(!std::is_invocable_v<RangeEmptyT, int (&)[]>);
+static_assert(!std::is_invocable_v<RangeEmptyT, int (&&)[]>);
+static_assert(std::is_invocable_v<RangeEmptyT, int[1]>);
+static_assert(std::is_invocable_v<RangeEmptyT, int const[1]>);
+static_assert(std::is_invocable_v<RangeEmptyT, int (&&)[1]>);
+static_assert(std::is_invocable_v<RangeEmptyT, int (&)[1]>);
+static_assert(std::is_invocable_v<RangeEmptyT, int const (&)[1]>);
+
+struct Incomplete;
+static_assert(!std::is_invocable_v<RangeEmptyT, Incomplete[]>);
+static_assert(!std::is_invocable_v<RangeEmptyT, Incomplete (&)[]>);
+static_assert(!std::is_invocable_v<RangeEmptyT, Incomplete (&&)[]>);
+static_assert(!std::is_invocable_v<RangeEmptyT, Incomplete (&)[1]>);
+static_assert(!std::is_invocable_v<RangeEmptyT, Incomplete (&&)[1]>);
+static_assert(!std::is_invocable_v<RangeEmptyT, Incomplete const (&)[1]>);
+static_assert(!std::is_invocable_v<RangeEmptyT, Incomplete const (&&)[1]>);
+
+struct InputRangeWithoutSize {
+    cpp17_input_iterator<int*> begin() const;
+    cpp17_input_iterator<int*> end() const;
+};
+static_assert(!std::is_invocable_v<RangeEmptyT, InputRangeWithoutSize const&>);
+
+struct NonConstEmpty {
+    bool empty();
+};
+static_assert(!std::is_invocable_v<RangeEmptyT, NonConstEmpty const&>);
+
+struct HasMemberAndFunction {
+    constexpr bool empty() const { return true; }
+    // We should never do ADL lookup for xranges::empty.
+    friend bool empty(HasMemberAndFunction const&) { return false; }
+};
+
+struct BadReturnType {
+    BadReturnType empty() { return {}; }
+};
+static_assert(!std::is_invocable_v<RangeEmptyT, BadReturnType&>);
+
+struct BoolConvertible {
+    constexpr explicit operator bool() noexcept(false) { return true; }
+};
+struct BoolConvertibleReturnType {
+    constexpr BoolConvertible empty() noexcept { return {}; }
+};
+static_assert(!noexcept(xranges::empty(BoolConvertibleReturnType())));
+
+struct InputIterators {
+    cpp17_input_iterator<int*> begin() const;
+    cpp17_input_iterator<int*> end() const;
+};
+static_assert(
+    std::is_same_v<decltype(InputIterators().begin() == InputIterators().end()),
+        bool>);
+static_assert(!std::is_invocable_v<RangeEmptyT, InputIterators const&>);
+
+constexpr bool testEmptyMember() {
+    HasMemberAndFunction a;
+    assert(xranges::empty(a));
+
+    BoolConvertibleReturnType b;
+    assert(xranges::empty(b));
+
+    return true;
+}
+
+struct SizeMember {
+    std::size_t size_;
+    constexpr std::size_t size() const { return size_; }
+};
+
+struct SizeFunction {
+    std::size_t size_;
+    friend constexpr std::size_t size(SizeFunction sf) { return sf.size_; }
+};
+
+struct BeginEndSizedSentinel {
+    constexpr int* begin() const { return nullptr; }
+    constexpr auto end() const { return sized_sentinel<int*>(nullptr); }
+};
+static_assert(xranges::forward_range<BeginEndSizedSentinel>);
+static_assert(xranges::sized_range<BeginEndSizedSentinel>);
+
+constexpr bool testUsingRangesSize() {
+    SizeMember a{1};
+    assert(!xranges::empty(a));
+    SizeMember b{0};
+    assert(xranges::empty(b));
+
+    SizeFunction c{1};
+    assert(!xranges::empty(c));
+    SizeFunction d{0};
+    assert(xranges::empty(d));
+
+    BeginEndSizedSentinel e;
+    assert(xranges::empty(e));
+
+    return true;
+}
+
+struct BeginEndNotSizedSentinel {
+    constexpr int* begin() const { return nullptr; }
+    constexpr auto end() const { return sentinel_wrapper<int*>(nullptr); }
+};
+static_assert(xranges::forward_range<BeginEndNotSizedSentinel>);
+static_assert(!xranges::sized_range<BeginEndNotSizedSentinel>);
+
+// size is disabled here, so we have to compare begin and end.
+struct DisabledSizeRangeWithBeginEnd {
+    constexpr int* begin() const { return nullptr; }
+    constexpr auto end() const { return sentinel_wrapper<int*>(nullptr); }
+    std::size_t size() const;
+};
+template <>
+inline constexpr bool
+    std::ranges::disable_sized_range<DisabledSizeRangeWithBeginEnd> = true;
+static_assert(xranges::contiguous_range<DisabledSizeRangeWithBeginEnd>);
+static_assert(!xranges::sized_range<DisabledSizeRangeWithBeginEnd>);
+
+struct BeginEndAndEmpty {
+    constexpr int* begin() const { return nullptr; }
+    constexpr auto end() const { return sentinel_wrapper<int*>(nullptr); }
+    constexpr bool empty() { return false; }
+};
+
+struct EvilBeginEnd {
+    bool empty() &&;
+    constexpr int* begin() & { return nullptr; }
+    constexpr int* end() & { return nullptr; }
+};
+
+constexpr bool testBeginEqualsEnd() {
+    BeginEndNotSizedSentinel a;
+    assert(xranges::empty(a));
+
+    DisabledSizeRangeWithBeginEnd d;
+    assert(xranges::empty(d));
+
+    BeginEndAndEmpty e;
+    assert(!xranges::empty(e));               // e.empty()
+    assert(xranges::empty(std::as_const(e))); // e.begin() == e.end()
+
+    assert(xranges::empty(EvilBeginEnd()));
+
+    return true;
+}
+
+// Test ADL-proofing.
+struct Incomplete;
+template <class T>
+struct Holder {
+    T t;
+};
+static_assert(!std::is_invocable_v<RangeEmptyT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeEmptyT, Holder<Incomplete>*&>);
+
+int main(int, char**) {
+    testEmptyMember();
+    static_assert(testEmptyMember());
+
+    testUsingRangesSize();
+    static_assert(testUsingRangesSize());
+
+    testBeginEqualsEnd();
+    static_assert(testBeginEqualsEnd());
+
+    return 0;
+}

--- a/llvm/access/empty.verify.cpp
+++ b/llvm/access/empty.verify.cpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::empty
+
+#include <ranges>
+
+extern int arr[];
+
+// Verify that for an array of unknown bound `ranges::empty` is ill-formed.
+void test() {
+  std::ranges::empty(arr);
+  // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?__empty::__fn'}}}}
+}

--- a/llvm/access/empty.verify.cpp
+++ b/llvm/access/empty.verify.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/empty.verify.cpp
+++ b/llvm/access/empty.verify.cpp
@@ -11,14 +11,21 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::empty
+// rxx::ranges::empty
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
 
 extern int arr[];
 
 // Verify that for an array of unknown bound `ranges::empty` is ill-formed.
 void test() {
-  std::ranges::empty(arr);
-  // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?__empty::__fn'}}}}
+    xranges::empty(arr);
+    // clang-format off
+    // expected-error-re@-1 {{{{no matching function for call to object of type 'const (rxx::ranges::)?details::empty_t'}}}}
+    // clang-format on
 }

--- a/llvm/access/end.pass.cpp
+++ b/llvm/access/end.pass.cpp
@@ -1,0 +1,370 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::end
+// std::ranges::cend
+
+#include <ranges>
+
+#include <cassert>
+#include <utility>
+#include "test_macros.h"
+#include "test_iterators.h"
+
+using RangeEndT = decltype(std::ranges::end);
+using RangeCEndT = decltype(std::ranges::cend);
+
+static int globalBuff[8];
+
+static_assert(!std::is_invocable_v<RangeEndT, int (&&)[]>);
+static_assert(!std::is_invocable_v<RangeEndT, int (&)[]>);
+static_assert(!std::is_invocable_v<RangeEndT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeEndT, int (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCEndT, int (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCEndT, int (&)[]>);
+static_assert(!std::is_invocable_v<RangeCEndT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeCEndT, int (&)[10]>);
+
+struct Incomplete;
+static_assert(!std::is_invocable_v<RangeEndT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeEndT, Incomplete(&&)[42]>);
+static_assert(!std::is_invocable_v<RangeCEndT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeCEndT, Incomplete(&&)[42]>);
+
+struct EndMember {
+  int x;
+  const int *begin() const;
+  constexpr const int *end() const { return &x; }
+};
+
+// Ensure that we can't call with rvalues with borrowing disabled.
+static_assert( std::is_invocable_v<RangeEndT, EndMember &>);
+static_assert(!std::is_invocable_v<RangeEndT, EndMember &&>);
+static_assert( std::is_invocable_v<RangeEndT, EndMember const&>);
+static_assert(!std::is_invocable_v<RangeEndT, EndMember const&&>);
+static_assert( std::is_invocable_v<RangeCEndT, EndMember &>);
+static_assert(!std::is_invocable_v<RangeCEndT, EndMember &&>);
+static_assert( std::is_invocable_v<RangeCEndT, EndMember const&>);
+static_assert(!std::is_invocable_v<RangeCEndT, EndMember const&&>);
+
+constexpr bool testReturnTypes() {
+  {
+    int *x[2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::end(x)), int**);
+    ASSERT_SAME_TYPE(decltype(std::ranges::cend(x)), int* const*);
+  }
+  {
+    int x[2][2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::end(x)), int(*)[2]);
+    ASSERT_SAME_TYPE(decltype(std::ranges::cend(x)), const int(*)[2]);
+  }
+  {
+    struct Different {
+      char *begin();
+      sentinel_wrapper<char*>& end();
+      short *begin() const;
+      sentinel_wrapper<short*>& end() const;
+    } x;
+    ASSERT_SAME_TYPE(decltype(std::ranges::end(x)), sentinel_wrapper<char*>);
+    ASSERT_SAME_TYPE(decltype(std::ranges::cend(x)), sentinel_wrapper<short*>);
+  }
+  return true;
+}
+
+constexpr bool testArray() {
+  int a[2];
+  assert(std::ranges::end(a) == a + 2);
+  assert(std::ranges::cend(a) == a + 2);
+
+  int b[2][2];
+  assert(std::ranges::end(b) == b + 2);
+  assert(std::ranges::cend(b) == b + 2);
+
+  EndMember c[2];
+  assert(std::ranges::end(c) == c + 2);
+  assert(std::ranges::cend(c) == c + 2);
+
+  return true;
+}
+
+struct EndMemberReturnsInt {
+  int begin() const;
+  int end() const;
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndMemberReturnsInt const&>);
+
+struct EndMemberReturnsVoidPtr {
+  const void *begin() const;
+  const void *end() const;
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndMemberReturnsVoidPtr const&>);
+
+struct PtrConvertible {
+  operator int*() const;
+};
+struct PtrConvertibleEndMember {
+  PtrConvertible begin() const;
+  PtrConvertible end() const;
+};
+static_assert(!std::is_invocable_v<RangeEndT, PtrConvertibleEndMember const&>);
+
+struct NoBeginMember {
+  constexpr const int *end();
+};
+static_assert(!std::is_invocable_v<RangeEndT, NoBeginMember const&>);
+
+struct NonConstEndMember {
+  int x;
+  constexpr int *begin() { return nullptr; }
+  constexpr int *end() { return &x; }
+};
+static_assert( std::is_invocable_v<RangeEndT,  NonConstEndMember &>);
+static_assert(!std::is_invocable_v<RangeEndT,  NonConstEndMember const&>);
+static_assert(!std::is_invocable_v<RangeCEndT, NonConstEndMember &>);
+static_assert(!std::is_invocable_v<RangeCEndT, NonConstEndMember const&>);
+
+struct EnabledBorrowingEndMember {
+  constexpr int *begin() const { return nullptr; }
+  constexpr int *end() const { return &globalBuff[0]; }
+};
+
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<EnabledBorrowingEndMember> = true;
+
+struct EndMemberFunction {
+  int x;
+  constexpr const int *begin() const { return nullptr; }
+  constexpr const int *end() const { return &x; }
+  friend constexpr int *end(EndMemberFunction const&);
+};
+
+struct Empty { };
+struct EmptyEndMember {
+  Empty begin() const;
+  Empty end() const;
+};
+static_assert(!std::is_invocable_v<RangeEndT, EmptyEndMember const&>);
+
+struct EmptyPtrEndMember {
+  Empty x;
+  constexpr const Empty *begin() const { return nullptr; }
+  constexpr const Empty *end() const { return &x; }
+};
+
+constexpr bool testEndMember() {
+  EndMember a;
+  assert(std::ranges::end(a) == &a.x);
+  assert(std::ranges::cend(a) == &a.x);
+
+  NonConstEndMember b;
+  assert(std::ranges::end(b) == &b.x);
+  static_assert(!std::is_invocable_v<RangeCEndT, decltype((b))>);
+
+  EnabledBorrowingEndMember c;
+  assert(std::ranges::end(std::move(c)) == &globalBuff[0]);
+  assert(std::ranges::cend(std::move(c)) == &globalBuff[0]);
+
+  EndMemberFunction d;
+  assert(std::ranges::end(d) == &d.x);
+  assert(std::ranges::cend(d) == &d.x);
+
+  EmptyPtrEndMember e;
+  assert(std::ranges::end(e) == &e.x);
+  assert(std::ranges::cend(e) == &e.x);
+
+  return true;
+}
+
+struct EndFunction {
+  int x;
+  friend constexpr const int *begin(EndFunction const&) { return nullptr; }
+  friend constexpr const int *end(EndFunction const& bf) { return &bf.x; }
+};
+
+static_assert( std::is_invocable_v<RangeEndT, EndFunction const&>);
+static_assert(!std::is_invocable_v<RangeEndT, EndFunction &&>);
+
+static_assert( std::is_invocable_v<RangeEndT,  EndFunction const&>);
+static_assert(!std::is_invocable_v<RangeEndT,  EndFunction &&>);
+static_assert(std::is_invocable_v<RangeEndT, EndFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+static_assert( std::is_invocable_v<RangeCEndT, EndFunction const&>);
+static_assert( std::is_invocable_v<RangeCEndT, EndFunction &>);
+
+struct EndFunctionReturnsInt {
+  friend constexpr int begin(EndFunctionReturnsInt const&);
+  friend constexpr int end(EndFunctionReturnsInt const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsInt const&>);
+
+struct EndFunctionReturnsVoidPtr {
+  friend constexpr void *begin(EndFunctionReturnsVoidPtr const&);
+  friend constexpr void *end(EndFunctionReturnsVoidPtr const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsVoidPtr const&>);
+
+struct EndFunctionReturnsEmpty {
+  friend constexpr Empty begin(EndFunctionReturnsEmpty const&);
+  friend constexpr Empty end(EndFunctionReturnsEmpty const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsEmpty const&>);
+
+struct EndFunctionReturnsPtrConvertible {
+  friend constexpr PtrConvertible begin(EndFunctionReturnsPtrConvertible const&);
+  friend constexpr PtrConvertible end(EndFunctionReturnsPtrConvertible const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsPtrConvertible const&>);
+
+struct NoBeginFunction {
+  friend constexpr const int *end(NoBeginFunction const&);
+};
+static_assert(!std::is_invocable_v<RangeEndT, NoBeginFunction const&>);
+
+struct EndFunctionByValue {
+  friend constexpr int *begin(EndFunctionByValue) { return nullptr; }
+  friend constexpr int *end(EndFunctionByValue) { return &globalBuff[1]; }
+};
+static_assert(!std::is_invocable_v<RangeCEndT, EndFunctionByValue>);
+
+struct EndFunctionEnabledBorrowing {
+  friend constexpr int *begin(EndFunctionEnabledBorrowing) { return nullptr; }
+  friend constexpr int *end(EndFunctionEnabledBorrowing) { return &globalBuff[2]; }
+};
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<EndFunctionEnabledBorrowing> = true;
+
+struct EndFunctionReturnsEmptyPtr {
+  Empty x;
+  friend constexpr const Empty *begin(EndFunctionReturnsEmptyPtr const&) { return nullptr; }
+  friend constexpr const Empty *end(EndFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+};
+
+struct EndFunctionWithDataMember {
+  int x;
+  int end;
+  friend constexpr const int *begin(EndFunctionWithDataMember const&) { return nullptr; }
+  friend constexpr const int *end(EndFunctionWithDataMember const& bf) { return &bf.x; }
+};
+
+struct EndFunctionWithPrivateEndMember {
+  int y;
+  friend constexpr const int *begin(EndFunctionWithPrivateEndMember const&) { return nullptr; }
+  friend constexpr const int *end(EndFunctionWithPrivateEndMember const& bf) { return &bf.y; }
+private:
+  const int *end() const;
+};
+
+struct BeginMemberEndFunction {
+  int x;
+  constexpr const int *begin() const { return nullptr; }
+  friend constexpr const int *end(BeginMemberEndFunction const& bf) { return &bf.x; }
+};
+
+constexpr bool testEndFunction() {
+  const EndFunction a{};
+  assert(std::ranges::end(a) == &a.x);
+  assert(std::ranges::cend(a) == &a.x);
+  EndFunction aa{};
+  assert(std::ranges::end(aa) == &aa.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::cend(aa) == &aa.x);
+
+  EndFunctionByValue b;
+  assert(std::ranges::end(b) == &globalBuff[1]);
+  assert(std::ranges::cend(b) == &globalBuff[1]);
+
+  EndFunctionEnabledBorrowing c;
+  assert(std::ranges::end(std::move(c)) == &globalBuff[2]);
+  assert(std::ranges::cend(std::move(c)) == &globalBuff[2]);
+
+  const EndFunctionReturnsEmptyPtr d{};
+  assert(std::ranges::end(d) == &d.x);
+  assert(std::ranges::cend(d) == &d.x);
+  EndFunctionReturnsEmptyPtr dd{};
+  assert(std::ranges::end(dd) == &dd.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::cend(dd) == &dd.x);
+
+  const EndFunctionWithDataMember e{};
+  assert(std::ranges::end(e) == &e.x);
+  assert(std::ranges::cend(e) == &e.x);
+  EndFunctionWithDataMember ee{};
+  assert(std::ranges::end(ee) == &ee.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::cend(ee) == &ee.x);
+
+  const EndFunctionWithPrivateEndMember f{};
+  assert(std::ranges::end(f) == &f.y);
+  assert(std::ranges::cend(f) == &f.y);
+  EndFunctionWithPrivateEndMember ff{};
+  assert(std::ranges::end(ff) == &ff.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::cend(ff) == &ff.y);
+
+  const BeginMemberEndFunction g{};
+  assert(std::ranges::end(g) == &g.x);
+  assert(std::ranges::cend(g) == &g.x);
+  BeginMemberEndFunction gg{};
+  assert(std::ranges::end(gg) == &gg.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::cend(gg) == &gg.x);
+
+  return true;
+}
+
+
+ASSERT_NOEXCEPT(std::ranges::end(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(std::ranges::cend(std::declval<int (&)[10]>()));
+
+struct NoThrowMemberEnd {
+  ThrowingIterator<int> begin() const;
+  ThrowingIterator<int> end() const noexcept; // auto(t.end()) doesn't throw
+} ntme;
+static_assert(noexcept(std::ranges::end(ntme)));
+static_assert(noexcept(std::ranges::cend(ntme)));
+
+struct NoThrowADLEnd {
+  ThrowingIterator<int> begin() const;
+  friend ThrowingIterator<int> end(NoThrowADLEnd&) noexcept;  // auto(end(t)) doesn't throw
+  friend ThrowingIterator<int> end(const NoThrowADLEnd&) noexcept;
+} ntae;
+static_assert(noexcept(std::ranges::end(ntae)));
+static_assert(noexcept(std::ranges::cend(ntae)));
+
+struct NoThrowMemberEndReturnsRef {
+  ThrowingIterator<int> begin() const;
+  ThrowingIterator<int>& end() const noexcept; // auto(t.end()) may throw
+} ntmerr;
+static_assert(!noexcept(std::ranges::end(ntmerr)));
+static_assert(!noexcept(std::ranges::cend(ntmerr)));
+
+struct EndReturnsArrayRef {
+    auto begin() const noexcept -> int(&)[10];
+    auto end() const noexcept -> int(&)[10];
+} erar;
+static_assert(noexcept(std::ranges::end(erar)));
+static_assert(noexcept(std::ranges::cend(erar)));
+
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(!std::is_invocable_v<RangeEndT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeEndT, Holder<Incomplete>*&>);
+static_assert(!std::is_invocable_v<RangeCEndT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeCEndT, Holder<Incomplete>*&>);
+
+int main(int, char**) {
+  static_assert(testReturnTypes());
+
+  testArray();
+  static_assert(testArray());
+
+  testEndMember();
+  static_assert(testEndMember());
+
+  testEndFunction();
+  static_assert(testEndFunction());
+
+  return 0;
+}

--- a/llvm/access/end.pass.cpp
+++ b/llvm/access/end.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -8,363 +11,399 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::end
-// std::ranges::cend
+// xranges::end
+// xranges::cend
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
 
 #include <cassert>
+#include <ranges>
 #include <utility>
-#include "test_macros.h"
-#include "test_iterators.h"
 
-using RangeEndT = decltype(std::ranges::end);
-using RangeCEndT = decltype(std::ranges::cend);
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
+
+using RangeEndT = decltype(xranges::end);
+using RangeCEndT = decltype(xranges::cend);
 
 static int globalBuff[8];
 
 static_assert(!std::is_invocable_v<RangeEndT, int (&&)[]>);
 static_assert(!std::is_invocable_v<RangeEndT, int (&)[]>);
 static_assert(!std::is_invocable_v<RangeEndT, int (&&)[10]>);
-static_assert( std::is_invocable_v<RangeEndT, int (&)[10]>);
+static_assert(std::is_invocable_v<RangeEndT, int (&)[10]>);
 static_assert(!std::is_invocable_v<RangeCEndT, int (&&)[]>);
 static_assert(!std::is_invocable_v<RangeCEndT, int (&)[]>);
 static_assert(!std::is_invocable_v<RangeCEndT, int (&&)[10]>);
-static_assert( std::is_invocable_v<RangeCEndT, int (&)[10]>);
+static_assert(std::is_invocable_v<RangeCEndT, int (&)[10]>);
 
 struct Incomplete;
-static_assert(!std::is_invocable_v<RangeEndT, Incomplete(&&)[]>);
-static_assert(!std::is_invocable_v<RangeEndT, Incomplete(&&)[42]>);
-static_assert(!std::is_invocable_v<RangeCEndT, Incomplete(&&)[]>);
-static_assert(!std::is_invocable_v<RangeCEndT, Incomplete(&&)[42]>);
+static_assert(!std::is_invocable_v<RangeEndT, Incomplete (&&)[]>);
+static_assert(!std::is_invocable_v<RangeEndT, Incomplete (&&)[42]>);
+static_assert(!std::is_invocable_v<RangeCEndT, Incomplete (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCEndT, Incomplete (&&)[42]>);
 
 struct EndMember {
-  int x;
-  const int *begin() const;
-  constexpr const int *end() const { return &x; }
+    int x;
+    int const* begin() const;
+    constexpr int const* end() const { return &x; }
 };
 
 // Ensure that we can't call with rvalues with borrowing disabled.
-static_assert( std::is_invocable_v<RangeEndT, EndMember &>);
-static_assert(!std::is_invocable_v<RangeEndT, EndMember &&>);
-static_assert( std::is_invocable_v<RangeEndT, EndMember const&>);
+static_assert(std::is_invocable_v<RangeEndT, EndMember&>);
+static_assert(!std::is_invocable_v<RangeEndT, EndMember&&>);
+static_assert(std::is_invocable_v<RangeEndT, EndMember const&>);
 static_assert(!std::is_invocable_v<RangeEndT, EndMember const&&>);
-static_assert( std::is_invocable_v<RangeCEndT, EndMember &>);
-static_assert(!std::is_invocable_v<RangeCEndT, EndMember &&>);
-static_assert( std::is_invocable_v<RangeCEndT, EndMember const&>);
+static_assert(std::is_invocable_v<RangeCEndT, EndMember&>);
+static_assert(!std::is_invocable_v<RangeCEndT, EndMember&&>);
+static_assert(std::is_invocable_v<RangeCEndT, EndMember const&>);
 static_assert(!std::is_invocable_v<RangeCEndT, EndMember const&&>);
 
 constexpr bool testReturnTypes() {
-  {
-    int *x[2];
-    ASSERT_SAME_TYPE(decltype(std::ranges::end(x)), int**);
-    ASSERT_SAME_TYPE(decltype(std::ranges::cend(x)), int* const*);
-  }
-  {
-    int x[2][2];
-    ASSERT_SAME_TYPE(decltype(std::ranges::end(x)), int(*)[2]);
-    ASSERT_SAME_TYPE(decltype(std::ranges::cend(x)), const int(*)[2]);
-  }
-  {
-    struct Different {
-      char *begin();
-      sentinel_wrapper<char*>& end();
-      short *begin() const;
-      sentinel_wrapper<short*>& end() const;
-    } x;
-    ASSERT_SAME_TYPE(decltype(std::ranges::end(x)), sentinel_wrapper<char*>);
-    ASSERT_SAME_TYPE(decltype(std::ranges::cend(x)), sentinel_wrapper<short*>);
-  }
-  return true;
+    {
+        int* x[2];
+        ASSERT_SAME_TYPE(decltype(xranges::end(x)), int**);
+        ASSERT_SAME_TYPE(decltype(xranges::cend(x)), int* const*);
+    }
+    {
+        int x[2][2];
+        ASSERT_SAME_TYPE(decltype(xranges::end(x)), int(*)[2]);
+        ASSERT_SAME_TYPE(decltype(xranges::cend(x)), int const(*)[2]);
+    }
+    {
+        struct Different {
+            char* begin();
+            sentinel_wrapper<char*>& end();
+            short* begin() const;
+            sentinel_wrapper<short*>& end() const;
+        } x;
+        ASSERT_SAME_TYPE(decltype(xranges::end(x)), sentinel_wrapper<char*>);
+        ASSERT_SAME_TYPE(decltype(xranges::cend(x)), sentinel_wrapper<short*>);
+    }
+    return true;
 }
 
 constexpr bool testArray() {
-  int a[2];
-  assert(std::ranges::end(a) == a + 2);
-  assert(std::ranges::cend(a) == a + 2);
+    int a[2];
+    assert(xranges::end(a) == a + 2);
+    assert(xranges::cend(a) == a + 2);
 
-  int b[2][2];
-  assert(std::ranges::end(b) == b + 2);
-  assert(std::ranges::cend(b) == b + 2);
+    int b[2][2];
+    assert(xranges::end(b) == b + 2);
+    assert(xranges::cend(b) == b + 2);
 
-  EndMember c[2];
-  assert(std::ranges::end(c) == c + 2);
-  assert(std::ranges::cend(c) == c + 2);
+    EndMember c[2];
+    assert(xranges::end(c) == c + 2);
+    assert(xranges::cend(c) == c + 2);
 
-  return true;
+    return true;
 }
 
 struct EndMemberReturnsInt {
-  int begin() const;
-  int end() const;
+    int begin() const;
+    int end() const;
 };
 static_assert(!std::is_invocable_v<RangeEndT, EndMemberReturnsInt const&>);
 
 struct EndMemberReturnsVoidPtr {
-  const void *begin() const;
-  const void *end() const;
+    void const* begin() const;
+    void const* end() const;
 };
 static_assert(!std::is_invocable_v<RangeEndT, EndMemberReturnsVoidPtr const&>);
 
 struct PtrConvertible {
-  operator int*() const;
+    operator int*() const;
 };
 struct PtrConvertibleEndMember {
-  PtrConvertible begin() const;
-  PtrConvertible end() const;
+    PtrConvertible begin() const;
+    PtrConvertible end() const;
 };
 static_assert(!std::is_invocable_v<RangeEndT, PtrConvertibleEndMember const&>);
 
 struct NoBeginMember {
-  constexpr const int *end();
+    constexpr int const* end();
 };
 static_assert(!std::is_invocable_v<RangeEndT, NoBeginMember const&>);
 
 struct NonConstEndMember {
-  int x;
-  constexpr int *begin() { return nullptr; }
-  constexpr int *end() { return &x; }
+    int x;
+    constexpr int* begin() { return nullptr; }
+    constexpr int* end() { return &x; }
 };
-static_assert( std::is_invocable_v<RangeEndT,  NonConstEndMember &>);
-static_assert(!std::is_invocable_v<RangeEndT,  NonConstEndMember const&>);
-static_assert(!std::is_invocable_v<RangeCEndT, NonConstEndMember &>);
+static_assert(std::is_invocable_v<RangeEndT, NonConstEndMember&>);
+static_assert(!std::is_invocable_v<RangeEndT, NonConstEndMember const&>);
+static_assert(std::is_invocable_v<RangeCEndT, NonConstEndMember&>);
 static_assert(!std::is_invocable_v<RangeCEndT, NonConstEndMember const&>);
 
 struct EnabledBorrowingEndMember {
-  constexpr int *begin() const { return nullptr; }
-  constexpr int *end() const { return &globalBuff[0]; }
+    constexpr int* begin() const { return nullptr; }
+    constexpr int* end() const { return &globalBuff[0]; }
 };
 
-template<>
-inline constexpr bool std::ranges::enable_borrowed_range<EnabledBorrowingEndMember> = true;
+template <>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<EnabledBorrowingEndMember> = true;
 
 struct EndMemberFunction {
-  int x;
-  constexpr const int *begin() const { return nullptr; }
-  constexpr const int *end() const { return &x; }
-  friend constexpr int *end(EndMemberFunction const&);
+    int x;
+    constexpr int const* begin() const { return nullptr; }
+    constexpr int const* end() const { return &x; }
+    friend constexpr int* end(EndMemberFunction const&);
 };
 
-struct Empty { };
+struct Empty {};
 struct EmptyEndMember {
-  Empty begin() const;
-  Empty end() const;
+    Empty begin() const;
+    Empty end() const;
 };
 static_assert(!std::is_invocable_v<RangeEndT, EmptyEndMember const&>);
 
 struct EmptyPtrEndMember {
-  Empty x;
-  constexpr const Empty *begin() const { return nullptr; }
-  constexpr const Empty *end() const { return &x; }
+    Empty x;
+    constexpr Empty const* begin() const { return nullptr; }
+    constexpr Empty const* end() const { return &x; }
 };
 
 constexpr bool testEndMember() {
-  EndMember a;
-  assert(std::ranges::end(a) == &a.x);
-  assert(std::ranges::cend(a) == &a.x);
+    EndMember a;
+    assert(xranges::end(a) == &a.x);
+    assert(xranges::cend(a) == &a.x);
 
-  NonConstEndMember b;
-  assert(std::ranges::end(b) == &b.x);
-  static_assert(!std::is_invocable_v<RangeCEndT, decltype((b))>);
+    NonConstEndMember b;
+    assert(xranges::end(b) == &b.x);
+    static_assert(std::is_invocable_v<RangeCEndT, decltype((b))>);
 
-  EnabledBorrowingEndMember c;
-  assert(std::ranges::end(std::move(c)) == &globalBuff[0]);
-  assert(std::ranges::cend(std::move(c)) == &globalBuff[0]);
+    EnabledBorrowingEndMember c;
+    assert(xranges::end(std::move(c)) == &globalBuff[0]);
+    assert(xranges::cend(std::move(c)) == &globalBuff[0]);
 
-  EndMemberFunction d;
-  assert(std::ranges::end(d) == &d.x);
-  assert(std::ranges::cend(d) == &d.x);
+    EndMemberFunction d;
+    assert(xranges::end(d) == &d.x);
+    assert(xranges::cend(d) == &d.x);
 
-  EmptyPtrEndMember e;
-  assert(std::ranges::end(e) == &e.x);
-  assert(std::ranges::cend(e) == &e.x);
+    EmptyPtrEndMember e;
+    assert(xranges::end(e) == &e.x);
+    assert(xranges::cend(e) == &e.x);
 
-  return true;
+    return true;
 }
 
 struct EndFunction {
-  int x;
-  friend constexpr const int *begin(EndFunction const&) { return nullptr; }
-  friend constexpr const int *end(EndFunction const& bf) { return &bf.x; }
+    int x;
+    friend constexpr int const* begin(EndFunction const&) { return nullptr; }
+    friend constexpr int const* end(EndFunction const& bf) { return &bf.x; }
 };
 
-static_assert( std::is_invocable_v<RangeEndT, EndFunction const&>);
-static_assert(!std::is_invocable_v<RangeEndT, EndFunction &&>);
+static_assert(std::is_invocable_v<RangeEndT, EndFunction const&>);
+static_assert(!std::is_invocable_v<RangeEndT, EndFunction&&>);
 
-static_assert( std::is_invocable_v<RangeEndT,  EndFunction const&>);
-static_assert(!std::is_invocable_v<RangeEndT,  EndFunction &&>);
-static_assert(std::is_invocable_v<RangeEndT, EndFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-static_assert( std::is_invocable_v<RangeCEndT, EndFunction const&>);
-static_assert( std::is_invocable_v<RangeCEndT, EndFunction &>);
+static_assert(std::is_invocable_v<RangeEndT, EndFunction const&>);
+static_assert(!std::is_invocable_v<RangeEndT, EndFunction&&>);
+static_assert(std::is_invocable_v<RangeEndT,
+    EndFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+static_assert(std::is_invocable_v<RangeCEndT, EndFunction const&>);
+static_assert(std::is_invocable_v<RangeCEndT, EndFunction&>);
 
 struct EndFunctionReturnsInt {
-  friend constexpr int begin(EndFunctionReturnsInt const&);
-  friend constexpr int end(EndFunctionReturnsInt const&);
+    friend constexpr int begin(EndFunctionReturnsInt const&);
+    friend constexpr int end(EndFunctionReturnsInt const&);
 };
 static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsInt const&>);
 
 struct EndFunctionReturnsVoidPtr {
-  friend constexpr void *begin(EndFunctionReturnsVoidPtr const&);
-  friend constexpr void *end(EndFunctionReturnsVoidPtr const&);
+    friend constexpr void* begin(EndFunctionReturnsVoidPtr const&);
+    friend constexpr void* end(EndFunctionReturnsVoidPtr const&);
 };
-static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsVoidPtr const&>);
+static_assert(
+    !std::is_invocable_v<RangeEndT, EndFunctionReturnsVoidPtr const&>);
 
 struct EndFunctionReturnsEmpty {
-  friend constexpr Empty begin(EndFunctionReturnsEmpty const&);
-  friend constexpr Empty end(EndFunctionReturnsEmpty const&);
+    friend constexpr Empty begin(EndFunctionReturnsEmpty const&);
+    friend constexpr Empty end(EndFunctionReturnsEmpty const&);
 };
 static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsEmpty const&>);
 
 struct EndFunctionReturnsPtrConvertible {
-  friend constexpr PtrConvertible begin(EndFunctionReturnsPtrConvertible const&);
-  friend constexpr PtrConvertible end(EndFunctionReturnsPtrConvertible const&);
+    friend constexpr PtrConvertible begin(
+        EndFunctionReturnsPtrConvertible const&);
+    friend constexpr PtrConvertible end(
+        EndFunctionReturnsPtrConvertible const&);
 };
-static_assert(!std::is_invocable_v<RangeEndT, EndFunctionReturnsPtrConvertible const&>);
+static_assert(
+    !std::is_invocable_v<RangeEndT, EndFunctionReturnsPtrConvertible const&>);
 
 struct NoBeginFunction {
-  friend constexpr const int *end(NoBeginFunction const&);
+    friend constexpr int const* end(NoBeginFunction const&);
 };
 static_assert(!std::is_invocable_v<RangeEndT, NoBeginFunction const&>);
 
 struct EndFunctionByValue {
-  friend constexpr int *begin(EndFunctionByValue) { return nullptr; }
-  friend constexpr int *end(EndFunctionByValue) { return &globalBuff[1]; }
+    friend constexpr int* begin(EndFunctionByValue) { return nullptr; }
+    friend constexpr int* end(EndFunctionByValue) { return &globalBuff[1]; }
 };
 static_assert(!std::is_invocable_v<RangeCEndT, EndFunctionByValue>);
 
 struct EndFunctionEnabledBorrowing {
-  friend constexpr int *begin(EndFunctionEnabledBorrowing) { return nullptr; }
-  friend constexpr int *end(EndFunctionEnabledBorrowing) { return &globalBuff[2]; }
+    friend constexpr int* begin(EndFunctionEnabledBorrowing) { return nullptr; }
+    friend constexpr int* end(EndFunctionEnabledBorrowing) {
+        return &globalBuff[2];
+    }
 };
-template<>
-inline constexpr bool std::ranges::enable_borrowed_range<EndFunctionEnabledBorrowing> = true;
+template <>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<EndFunctionEnabledBorrowing> = true;
 
 struct EndFunctionReturnsEmptyPtr {
-  Empty x;
-  friend constexpr const Empty *begin(EndFunctionReturnsEmptyPtr const&) { return nullptr; }
-  friend constexpr const Empty *end(EndFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+    Empty x;
+    friend constexpr Empty const* begin(EndFunctionReturnsEmptyPtr const&) {
+        return nullptr;
+    }
+    friend constexpr Empty const* end(EndFunctionReturnsEmptyPtr const& bf) {
+        return &bf.x;
+    }
 };
 
 struct EndFunctionWithDataMember {
-  int x;
-  int end;
-  friend constexpr const int *begin(EndFunctionWithDataMember const&) { return nullptr; }
-  friend constexpr const int *end(EndFunctionWithDataMember const& bf) { return &bf.x; }
+    int x;
+    int end;
+    friend constexpr int const* begin(EndFunctionWithDataMember const&) {
+        return nullptr;
+    }
+    friend constexpr int const* end(EndFunctionWithDataMember const& bf) {
+        return &bf.x;
+    }
 };
 
 struct EndFunctionWithPrivateEndMember {
-  int y;
-  friend constexpr const int *begin(EndFunctionWithPrivateEndMember const&) { return nullptr; }
-  friend constexpr const int *end(EndFunctionWithPrivateEndMember const& bf) { return &bf.y; }
+    int y;
+    friend constexpr int const* begin(EndFunctionWithPrivateEndMember const&) {
+        return nullptr;
+    }
+    friend constexpr int const* end(EndFunctionWithPrivateEndMember const& bf) {
+        return &bf.y;
+    }
+
 private:
-  const int *end() const;
+    int const* end() const;
 };
 
 struct BeginMemberEndFunction {
-  int x;
-  constexpr const int *begin() const { return nullptr; }
-  friend constexpr const int *end(BeginMemberEndFunction const& bf) { return &bf.x; }
+    int x;
+    constexpr int const* begin() const { return nullptr; }
+    friend constexpr int const* end(BeginMemberEndFunction const& bf) {
+        return &bf.x;
+    }
 };
 
 constexpr bool testEndFunction() {
-  const EndFunction a{};
-  assert(std::ranges::end(a) == &a.x);
-  assert(std::ranges::cend(a) == &a.x);
-  EndFunction aa{};
-  assert(std::ranges::end(aa) == &aa.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::cend(aa) == &aa.x);
+    EndFunction const a{};
+    assert(xranges::end(a) == &a.x);
+    assert(xranges::cend(a) == &a.x);
+    EndFunction aa{};
+    assert(xranges::end(aa) ==
+        &aa.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::cend(aa) == &aa.x);
 
-  EndFunctionByValue b;
-  assert(std::ranges::end(b) == &globalBuff[1]);
-  assert(std::ranges::cend(b) == &globalBuff[1]);
+    EndFunctionByValue b;
+    assert(xranges::end(b) == &globalBuff[1]);
+    assert(xranges::cend(b) == &globalBuff[1]);
 
-  EndFunctionEnabledBorrowing c;
-  assert(std::ranges::end(std::move(c)) == &globalBuff[2]);
-  assert(std::ranges::cend(std::move(c)) == &globalBuff[2]);
+    EndFunctionEnabledBorrowing c;
+    assert(xranges::end(std::move(c)) == &globalBuff[2]);
+    assert(xranges::cend(std::move(c)) == &globalBuff[2]);
 
-  const EndFunctionReturnsEmptyPtr d{};
-  assert(std::ranges::end(d) == &d.x);
-  assert(std::ranges::cend(d) == &d.x);
-  EndFunctionReturnsEmptyPtr dd{};
-  assert(std::ranges::end(dd) == &dd.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::cend(dd) == &dd.x);
+    EndFunctionReturnsEmptyPtr const d{};
+    assert(xranges::end(d) == &d.x);
+    assert(xranges::cend(d) == &d.x);
+    EndFunctionReturnsEmptyPtr dd{};
+    assert(xranges::end(dd) ==
+        &dd.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::cend(dd) == &dd.x);
 
-  const EndFunctionWithDataMember e{};
-  assert(std::ranges::end(e) == &e.x);
-  assert(std::ranges::cend(e) == &e.x);
-  EndFunctionWithDataMember ee{};
-  assert(std::ranges::end(ee) == &ee.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::cend(ee) == &ee.x);
+    EndFunctionWithDataMember const e{};
+    assert(xranges::end(e) == &e.x);
+    assert(xranges::cend(e) == &e.x);
+    EndFunctionWithDataMember ee{};
+    assert(xranges::end(ee) ==
+        &ee.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::cend(ee) == &ee.x);
 
-  const EndFunctionWithPrivateEndMember f{};
-  assert(std::ranges::end(f) == &f.y);
-  assert(std::ranges::cend(f) == &f.y);
-  EndFunctionWithPrivateEndMember ff{};
-  assert(std::ranges::end(ff) == &ff.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::cend(ff) == &ff.y);
+    EndFunctionWithPrivateEndMember const f{};
+    assert(xranges::end(f) == &f.y);
+    assert(xranges::cend(f) == &f.y);
+    EndFunctionWithPrivateEndMember ff{};
+    assert(xranges::end(ff) ==
+        &ff.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::cend(ff) == &ff.y);
 
-  const BeginMemberEndFunction g{};
-  assert(std::ranges::end(g) == &g.x);
-  assert(std::ranges::cend(g) == &g.x);
-  BeginMemberEndFunction gg{};
-  assert(std::ranges::end(gg) == &gg.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::cend(gg) == &gg.x);
+    BeginMemberEndFunction const g{};
+    assert(xranges::end(g) == &g.x);
+    assert(xranges::cend(g) == &g.x);
+    BeginMemberEndFunction gg{};
+    assert(xranges::end(gg) ==
+        &gg.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::cend(gg) == &gg.x);
 
-  return true;
+    return true;
 }
 
-
-ASSERT_NOEXCEPT(std::ranges::end(std::declval<int (&)[10]>()));
-ASSERT_NOEXCEPT(std::ranges::cend(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(xranges::end(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(xranges::cend(std::declval<int (&)[10]>()));
 
 struct NoThrowMemberEnd {
-  ThrowingIterator<int> begin() const;
-  ThrowingIterator<int> end() const noexcept; // auto(t.end()) doesn't throw
+    ThrowingIterator<int> begin() const;
+    ThrowingIterator<int> end() const noexcept; // auto(t.end()) doesn't throw
 } ntme;
-static_assert(noexcept(std::ranges::end(ntme)));
-static_assert(noexcept(std::ranges::cend(ntme)));
+static_assert(noexcept(xranges::end(ntme)));
+static_assert(noexcept(xranges::cend(ntme)));
 
 struct NoThrowADLEnd {
-  ThrowingIterator<int> begin() const;
-  friend ThrowingIterator<int> end(NoThrowADLEnd&) noexcept;  // auto(end(t)) doesn't throw
-  friend ThrowingIterator<int> end(const NoThrowADLEnd&) noexcept;
+    ThrowingIterator<int> begin() const;
+    friend ThrowingIterator<int> end(
+        NoThrowADLEnd&) noexcept; // auto(end(t)) doesn't throw
+    friend ThrowingIterator<int> end(NoThrowADLEnd const&) noexcept;
 } ntae;
-static_assert(noexcept(std::ranges::end(ntae)));
-static_assert(noexcept(std::ranges::cend(ntae)));
+static_assert(noexcept(xranges::end(ntae)));
+static_assert(noexcept(xranges::cend(ntae)));
 
 struct NoThrowMemberEndReturnsRef {
-  ThrowingIterator<int> begin() const;
-  ThrowingIterator<int>& end() const noexcept; // auto(t.end()) may throw
+    ThrowingIterator<int> begin() const;
+    ThrowingIterator<int>& end() const noexcept; // auto(t.end()) may throw
 } ntmerr;
-static_assert(!noexcept(std::ranges::end(ntmerr)));
-static_assert(!noexcept(std::ranges::cend(ntmerr)));
+static_assert(!noexcept(xranges::end(ntmerr)));
+static_assert(!noexcept(xranges::cend(ntmerr)));
 
 struct EndReturnsArrayRef {
-    auto begin() const noexcept -> int(&)[10];
-    auto end() const noexcept -> int(&)[10];
+    auto begin() const noexcept -> int (&)[10];
+    auto end() const noexcept -> int (&)[10];
 } erar;
-static_assert(noexcept(std::ranges::end(erar)));
-static_assert(noexcept(std::ranges::cend(erar)));
+static_assert(noexcept(xranges::end(erar)));
+static_assert(noexcept(xranges::cend(erar)));
 
 // Test ADL-proofing.
 struct Incomplete;
-template<class T> struct Holder { T t; };
+template <class T>
+struct Holder {
+    T t;
+};
 static_assert(!std::is_invocable_v<RangeEndT, Holder<Incomplete>*>);
 static_assert(!std::is_invocable_v<RangeEndT, Holder<Incomplete>*&>);
 static_assert(!std::is_invocable_v<RangeCEndT, Holder<Incomplete>*>);
 static_assert(!std::is_invocable_v<RangeCEndT, Holder<Incomplete>*&>);
 
 int main(int, char**) {
-  static_assert(testReturnTypes());
+    static_assert(testReturnTypes());
 
-  testArray();
-  static_assert(testArray());
+    testArray();
+    static_assert(testArray());
 
-  testEndMember();
-  static_assert(testEndMember());
+    testEndMember();
+    static_assert(testEndMember());
 
-  testEndFunction();
-  static_assert(testEndFunction());
+    testEndFunction();
+    static_assert(testEndFunction());
 
-  return 0;
+    return 0;
 }

--- a/llvm/access/end.sizezero.pass.cpp
+++ b/llvm/access/end.sizezero.pass.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+// UNSUPPORTED: msvc
+
+// std::ranges::end
+// std::ranges::cend
+//   Test the fix for https://llvm.org/PR54100
+
+#include <ranges>
+#include <cassert>
+
+#include "test_macros.h"
+
+struct A {
+  int m[0];
+};
+static_assert(sizeof(A) == 0); // an extension supported by GCC and Clang
+
+int main(int, char**)
+{
+  A a[10];
+  std::same_as<A*> auto p = std::ranges::end(a);
+  assert(p == a + 10);
+  std::same_as<const A*> auto cp = std::ranges::cend(a);
+  assert(cp == a + 10);
+
+  return 0;
+}

--- a/llvm/access/end.sizezero.pass.cpp
+++ b/llvm/access/end.sizezero.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -13,23 +16,34 @@
 // std::ranges::cend
 //   Test the fix for https://llvm.org/PR54100
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
 #include <cassert>
 
-#include "test_macros.h"
+#if RXX_COMPILER_CLANG | RXX_COMPILER_GCC
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
 
 struct A {
-  int m[0];
+    int m[0];
 };
 static_assert(sizeof(A) == 0); // an extension supported by GCC and Clang
 
-int main(int, char**)
-{
-  A a[10];
-  std::same_as<A*> auto p = std::ranges::end(a);
-  assert(p == a + 10);
-  std::same_as<const A*> auto cp = std::ranges::cend(a);
-  assert(cp == a + 10);
+int main() {
+    A a[10];
+    std::same_as<A*> auto p = xranges::end(a);
+    assert(p == a + 10);
+    std::same_as<A const*> auto cp = xranges::cend(a);
+    assert(cp == a + 10);
 
-  return 0;
+    return 0;
 }
+#else
+
+int main() {
+    return 0;
+}
+#endif

--- a/llvm/access/end.verify.cpp
+++ b/llvm/access/end.verify.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::end
+
+#include <ranges>
+
+struct NonBorrowedRange {
+  int* begin() const;
+  int* end() const;
+};
+static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
+
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::end` is ill-formed.
+void test() {
+  std::ranges::end(NonBorrowedRange());
+  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (std::ranges::)?__end::__fn'}}}}
+  // expected-error@-2  {{attempt to use a deleted function}}
+}

--- a/llvm/access/end.verify.cpp
+++ b/llvm/access/end.verify.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/end.verify.cpp
+++ b/llvm/access/end.verify.cpp
@@ -11,19 +11,27 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::end
+// rxx::ranges::end
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
 
 struct NonBorrowedRange {
-  int* begin() const;
-  int* end() const;
+    int* begin() const;
+    int* end() const;
 };
 static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
 
-// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::end` is ill-formed.
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is
+// false, `ranges::end` is ill-formed.
 void test() {
-  std::ranges::end(NonBorrowedRange());
-  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (std::ranges::)?__end::__fn'}}}}
-  // expected-error@-2  {{attempt to use a deleted function}}
+    xranges::end(NonBorrowedRange());
+    // clang-format off
+    // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (rxx::ranges::)?details::end_t'}}}}
+    // expected-error@-2  {{attempt to use a deleted function}}
+    // clang-format on
 }

--- a/llvm/access/rbegin.pass.cpp
+++ b/llvm/access/rbegin.pass.cpp
@@ -1,0 +1,521 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::rbegin
+// std::ranges::crbegin
+
+#include <ranges>
+
+#include <cassert>
+#include <utility>
+#include "test_macros.h"
+#include "test_iterators.h"
+
+using RangeRBeginT = decltype(std::ranges::rbegin);
+using RangeCRBeginT = decltype(std::ranges::crbegin);
+
+static int globalBuff[8];
+
+static_assert(!std::is_invocable_v<RangeRBeginT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeRBeginT, int (&)[10]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, int (&&)[]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, int (&)[]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeCRBeginT, int (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, int (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, int (&)[]>);
+
+struct Incomplete;
+
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, const Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, const Incomplete(&&)[]>);
+
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete(&&)[10]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, const Incomplete(&&)[10]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete(&&)[10]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, const Incomplete(&&)[10]>);
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeRBeginT, Incomplete(&)[]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeRBeginT, const Incomplete(&)[]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCRBeginT, Incomplete(&)[]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCRBeginT, const Incomplete(&)[]>);
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeRBeginT, Incomplete(&)[10]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeRBeginT, const Incomplete(&)[10]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCRBeginT, Incomplete(&)[10]>);
+LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCRBeginT, const Incomplete(&)[10]>);
+
+struct RBeginMember {
+  int x;
+  constexpr const int *rbegin() const { return &x; }
+};
+
+// Ensure that we can't call with rvalues with borrowing disabled.
+static_assert( std::is_invocable_v<RangeRBeginT, RBeginMember &>);
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMember &&>);
+static_assert( std::is_invocable_v<RangeRBeginT, RBeginMember const&>);
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMember const&&>);
+static_assert( std::is_invocable_v<RangeCRBeginT, RBeginMember &>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginMember &&>);
+static_assert( std::is_invocable_v<RangeCRBeginT, RBeginMember const&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginMember const&&>);
+
+constexpr bool testReturnTypes() {
+  {
+    int *x[2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::rbegin(x)), std::reverse_iterator<int**>);
+    ASSERT_SAME_TYPE(decltype(std::ranges::crbegin(x)), std::reverse_iterator<int* const*>);
+  }
+  {
+    int x[2][2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::rbegin(x)), std::reverse_iterator<int(*)[2]>);
+    ASSERT_SAME_TYPE(decltype(std::ranges::crbegin(x)), std::reverse_iterator<const int(*)[2]>);
+  }
+  {
+    struct Different {
+      char*& rbegin();
+      short*& rbegin() const;
+    } x;
+    ASSERT_SAME_TYPE(decltype(std::ranges::rbegin(x)), char*);
+    ASSERT_SAME_TYPE(decltype(std::ranges::crbegin(x)), short*);
+  }
+  return true;
+}
+
+constexpr bool testArray() {
+  int a[2];
+  assert(std::ranges::rbegin(a).base() == a + 2);
+  assert(std::ranges::crbegin(a).base() == a + 2);
+
+  int b[2][2];
+  assert(std::ranges::rbegin(b).base() == b + 2);
+  assert(std::ranges::crbegin(b).base() == b + 2);
+
+  RBeginMember c[2];
+  assert(std::ranges::rbegin(c).base() == c + 2);
+  assert(std::ranges::crbegin(c).base() == c + 2);
+
+  return true;
+}
+
+struct RBeginMemberReturnsInt {
+  int rbegin() const;
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMemberReturnsInt const&>);
+
+struct RBeginMemberReturnsVoidPtr {
+  const void *rbegin() const;
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMemberReturnsVoidPtr const&>);
+
+struct PtrConvertibleRBeginMember {
+  struct iterator { operator int*() const; };
+  iterator rbegin() const;
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, PtrConvertibleRBeginMember const&>);
+
+struct NonConstRBeginMember {
+  int x;
+  constexpr int* rbegin() { return &x; }
+};
+static_assert( std::is_invocable_v<RangeRBeginT,  NonConstRBeginMember &>);
+static_assert(!std::is_invocable_v<RangeRBeginT,  NonConstRBeginMember const&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, NonConstRBeginMember &>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, NonConstRBeginMember const&>);
+
+struct EnabledBorrowingRBeginMember {
+  constexpr int *rbegin() const { return globalBuff; }
+};
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<EnabledBorrowingRBeginMember> = true;
+
+struct RBeginMemberFunction {
+  int x;
+  constexpr const int *rbegin() const { return &x; }
+  friend int* rbegin(RBeginMemberFunction const&);
+};
+
+struct EmptyPtrRBeginMember {
+  struct Empty {};
+  Empty x;
+  constexpr const Empty* rbegin() const { return &x; }
+};
+
+constexpr bool testRBeginMember() {
+  RBeginMember a;
+  assert(std::ranges::rbegin(a) == &a.x);
+  assert(std::ranges::crbegin(a) == &a.x);
+  static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMember&&>);
+  static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginMember&&>);
+
+  NonConstRBeginMember b;
+  assert(std::ranges::rbegin(b) == &b.x);
+  static_assert(!std::is_invocable_v<RangeCRBeginT, NonConstRBeginMember&>);
+
+  EnabledBorrowingRBeginMember c;
+  assert(std::ranges::rbegin(c) == globalBuff);
+  assert(std::ranges::crbegin(c) == globalBuff);
+  assert(std::ranges::rbegin(std::move(c)) == globalBuff);
+  assert(std::ranges::crbegin(std::move(c)) == globalBuff);
+
+  RBeginMemberFunction d;
+  assert(std::ranges::rbegin(d) == &d.x);
+  assert(std::ranges::crbegin(d) == &d.x);
+
+  EmptyPtrRBeginMember e;
+  assert(std::ranges::rbegin(e) == &e.x);
+  assert(std::ranges::crbegin(e) == &e.x);
+
+  return true;
+}
+
+
+struct RBeginFunction {
+  int x;
+  friend constexpr const int* rbegin(RBeginFunction const& bf) { return &bf.x; }
+};
+static_assert( std::is_invocable_v<RangeRBeginT,  RBeginFunction const&>);
+static_assert(!std::is_invocable_v<RangeRBeginT,  RBeginFunction &&>);
+static_assert(
+    std::is_invocable_v<RangeRBeginT, RBeginFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+static_assert( std::is_invocable_v<RangeCRBeginT, RBeginFunction const&>);
+static_assert( std::is_invocable_v<RangeCRBeginT, RBeginFunction &>);
+
+struct RBeginFunctionReturnsInt {
+  friend int rbegin(RBeginFunctionReturnsInt const&);
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsInt const&>);
+
+struct RBeginFunctionReturnsVoidPtr {
+  friend void *rbegin(RBeginFunctionReturnsVoidPtr const&);
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsVoidPtr const&>);
+
+struct RBeginFunctionReturnsEmpty {
+  struct Empty {};
+  friend Empty rbegin(RBeginFunctionReturnsEmpty const&);
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsEmpty const&>);
+
+struct RBeginFunctionReturnsPtrConvertible {
+  struct iterator { operator int*() const; };
+  friend iterator rbegin(RBeginFunctionReturnsPtrConvertible const&);
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsPtrConvertible const&>);
+
+struct RBeginFunctionByValue {
+  friend constexpr int *rbegin(RBeginFunctionByValue) { return globalBuff + 1; }
+};
+static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginFunctionByValue>);
+
+struct RBeginFunctionEnabledBorrowing {
+  friend constexpr int *rbegin(RBeginFunctionEnabledBorrowing) { return globalBuff + 2; }
+};
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<RBeginFunctionEnabledBorrowing> = true;
+
+struct RBeginFunctionReturnsEmptyPtr {
+  struct Empty {};
+  Empty x;
+  friend constexpr const Empty *rbegin(RBeginFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+};
+
+struct RBeginFunctionWithDataMember {
+  int x;
+  int rbegin;
+  friend constexpr const int *rbegin(RBeginFunctionWithDataMember const& bf) { return &bf.x; }
+};
+
+struct RBeginFunctionWithPrivateBeginMember {
+  int y;
+  friend constexpr const int *rbegin(RBeginFunctionWithPrivateBeginMember const& bf) { return &bf.y; }
+private:
+  const int *rbegin() const;
+};
+
+constexpr bool testRBeginFunction() {
+  RBeginFunction a{};
+  const RBeginFunction aa{};
+  assert(std::ranges::rbegin(a) == &a.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::crbegin(a) == &a.x);
+  assert(std::ranges::rbegin(aa) == &aa.x);
+  assert(std::ranges::crbegin(aa) == &aa.x);
+
+  RBeginFunctionByValue b{};
+  const RBeginFunctionByValue bb{};
+  assert(std::ranges::rbegin(b) == globalBuff + 1);
+  assert(std::ranges::crbegin(b) == globalBuff + 1);
+  assert(std::ranges::rbegin(bb) == globalBuff + 1);
+  assert(std::ranges::crbegin(bb) == globalBuff + 1);
+
+  RBeginFunctionEnabledBorrowing c{};
+  const RBeginFunctionEnabledBorrowing cc{};
+  assert(std::ranges::rbegin(std::move(c)) == globalBuff + 2);
+  assert(std::ranges::crbegin(std::move(c)) == globalBuff + 2);
+  assert(std::ranges::rbegin(std::move(cc)) == globalBuff + 2);
+  assert(std::ranges::crbegin(std::move(cc)) == globalBuff + 2);
+
+  RBeginFunctionReturnsEmptyPtr d{};
+  const RBeginFunctionReturnsEmptyPtr dd{};
+  assert(std::ranges::rbegin(d) == &d.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::crbegin(d) == &d.x);
+  assert(std::ranges::rbegin(dd) == &dd.x);
+  assert(std::ranges::crbegin(dd) == &dd.x);
+
+  RBeginFunctionWithDataMember e{};
+  const RBeginFunctionWithDataMember ee{};
+  assert(std::ranges::rbegin(e) == &e.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::rbegin(ee) == &ee.x);
+  assert(std::ranges::crbegin(e) == &e.x);
+  assert(std::ranges::crbegin(ee) == &ee.x);
+
+  RBeginFunctionWithPrivateBeginMember f{};
+  const RBeginFunctionWithPrivateBeginMember ff{};
+  assert(std::ranges::rbegin(f) == &f.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::crbegin(f) == &f.y);
+  assert(std::ranges::rbegin(ff) == &ff.y);
+  assert(std::ranges::crbegin(ff) == &ff.y);
+
+  return true;
+}
+
+
+struct MemberBeginEnd {
+  int b, e;
+  char cb, ce;
+  constexpr bidirectional_iterator<int*> begin() { return bidirectional_iterator<int*>(&b); }
+  constexpr bidirectional_iterator<int*> end() { return bidirectional_iterator<int*>(&e); }
+  constexpr bidirectional_iterator<const char*> begin() const { return bidirectional_iterator<const char*>(&cb); }
+  constexpr bidirectional_iterator<const char*> end() const { return bidirectional_iterator<const char*>(&ce); }
+};
+static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginEnd&>);
+static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginEnd const&>);
+static_assert( std::is_invocable_v<RangeCRBeginT, MemberBeginEnd const&>);
+
+struct FunctionBeginEnd {
+  int b, e;
+  char cb, ce;
+  friend constexpr bidirectional_iterator<int*> begin(FunctionBeginEnd& v) {
+    return bidirectional_iterator<int*>(&v.b);
+  }
+  friend constexpr bidirectional_iterator<int*> end(FunctionBeginEnd& v) { return bidirectional_iterator<int*>(&v.e); }
+  friend constexpr bidirectional_iterator<const char*> begin(const FunctionBeginEnd& v) {
+    return bidirectional_iterator<const char*>(&v.cb);
+  }
+  friend constexpr bidirectional_iterator<const char*> end(const FunctionBeginEnd& v) {
+    return bidirectional_iterator<const char*>(&v.ce);
+  }
+};
+static_assert( std::is_invocable_v<RangeRBeginT, FunctionBeginEnd&>);
+static_assert( std::is_invocable_v<RangeRBeginT, FunctionBeginEnd const&>);
+static_assert( std::is_invocable_v<RangeCRBeginT, FunctionBeginEnd const&>);
+
+struct MemberBeginFunctionEnd {
+  int b, e;
+  char cb, ce;
+  constexpr bidirectional_iterator<int*> begin() { return bidirectional_iterator<int*>(&b); }
+  friend constexpr bidirectional_iterator<int*> end(MemberBeginFunctionEnd& v) {
+    return bidirectional_iterator<int*>(&v.e);
+  }
+  constexpr bidirectional_iterator<const char*> begin() const { return bidirectional_iterator<const char*>(&cb); }
+  friend constexpr bidirectional_iterator<const char*> end(const MemberBeginFunctionEnd& v) {
+    return bidirectional_iterator<const char*>(&v.ce);
+  }
+};
+static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginFunctionEnd&>);
+static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginFunctionEnd const&>);
+static_assert( std::is_invocable_v<RangeCRBeginT, MemberBeginFunctionEnd const&>);
+
+struct FunctionBeginMemberEnd {
+  int b, e;
+  char cb, ce;
+  friend constexpr bidirectional_iterator<int*> begin(FunctionBeginMemberEnd& v) {
+    return bidirectional_iterator<int*>(&v.b);
+  }
+  constexpr bidirectional_iterator<int*> end() { return bidirectional_iterator<int*>(&e); }
+  friend constexpr bidirectional_iterator<const char*> begin(const FunctionBeginMemberEnd& v) {
+    return bidirectional_iterator<const char*>(&v.cb);
+  }
+  constexpr bidirectional_iterator<const char*> end() const { return bidirectional_iterator<const char*>(&ce); }
+};
+static_assert( std::is_invocable_v<RangeRBeginT, FunctionBeginMemberEnd&>);
+static_assert( std::is_invocable_v<RangeRBeginT, FunctionBeginMemberEnd const&>);
+static_assert( std::is_invocable_v<RangeCRBeginT, FunctionBeginMemberEnd const&>);
+
+struct MemberBeginEndDifferentTypes {
+  bidirectional_iterator<int*> begin();
+  bidirectional_iterator<const int*> end();
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, MemberBeginEndDifferentTypes&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, MemberBeginEndDifferentTypes&>);
+
+struct FunctionBeginEndDifferentTypes {
+  friend bidirectional_iterator<int*> begin(FunctionBeginEndDifferentTypes&);
+  friend bidirectional_iterator<const int*> end(FunctionBeginEndDifferentTypes&);
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, FunctionBeginEndDifferentTypes&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, FunctionBeginEndDifferentTypes&>);
+
+struct MemberBeginEndForwardIterators {
+  forward_iterator<int*> begin();
+  forward_iterator<int*> end();
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, MemberBeginEndForwardIterators&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, MemberBeginEndForwardIterators&>);
+
+struct FunctionBeginEndForwardIterators {
+  friend forward_iterator<int*> begin(FunctionBeginEndForwardIterators&);
+  friend forward_iterator<int*> end(FunctionBeginEndForwardIterators&);
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, FunctionBeginEndForwardIterators&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, FunctionBeginEndForwardIterators&>);
+
+struct MemberBeginOnly {
+  bidirectional_iterator<int*> begin() const;
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, MemberBeginOnly&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, MemberBeginOnly&>);
+
+struct FunctionBeginOnly {
+  friend bidirectional_iterator<int*> begin(FunctionBeginOnly&);
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, FunctionBeginOnly&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, FunctionBeginOnly&>);
+
+struct MemberEndOnly {
+  bidirectional_iterator<int*> end() const;
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, MemberEndOnly&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, MemberEndOnly&>);
+
+struct FunctionEndOnly {
+  friend bidirectional_iterator<int*> end(FunctionEndOnly&);
+};
+static_assert(!std::is_invocable_v<RangeRBeginT, FunctionEndOnly&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, FunctionEndOnly&>);
+
+// Make sure there is no clash between the following cases:
+// - the case that handles classes defining member `rbegin` and `rend` functions;
+// - the case that handles classes defining `begin` and `end` functions returning reversible iterators.
+struct MemberBeginAndRBegin {
+  int* begin() const;
+  int* end() const;
+  int* rbegin() const;
+  int* rend() const;
+};
+static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginAndRBegin&>);
+static_assert( std::is_invocable_v<RangeCRBeginT, MemberBeginAndRBegin&>);
+static_assert( std::same_as<std::invoke_result_t<RangeRBeginT, MemberBeginAndRBegin&>, int*>);
+static_assert( std::same_as<std::invoke_result_t<RangeCRBeginT, MemberBeginAndRBegin&>, int*>);
+
+constexpr bool testBeginEnd() {
+  MemberBeginEnd a{};
+  const MemberBeginEnd aa{};
+  assert(base(std::ranges::rbegin(a).base()) == &a.e);
+  assert(base(std::ranges::crbegin(a).base()) == &a.ce);
+  assert(base(std::ranges::rbegin(aa).base()) == &aa.ce);
+  assert(base(std::ranges::crbegin(aa).base()) == &aa.ce);
+
+  FunctionBeginEnd b{};
+  const FunctionBeginEnd bb{};
+  assert(base(std::ranges::rbegin(b).base()) == &b.e);
+  assert(base(std::ranges::crbegin(b).base()) == &b.ce);
+  assert(base(std::ranges::rbegin(bb).base()) == &bb.ce);
+  assert(base(std::ranges::crbegin(bb).base()) == &bb.ce);
+
+  MemberBeginFunctionEnd c{};
+  const MemberBeginFunctionEnd cc{};
+  assert(base(std::ranges::rbegin(c).base()) == &c.e);
+  assert(base(std::ranges::crbegin(c).base()) == &c.ce);
+  assert(base(std::ranges::rbegin(cc).base()) == &cc.ce);
+  assert(base(std::ranges::crbegin(cc).base()) == &cc.ce);
+
+  FunctionBeginMemberEnd d{};
+  const FunctionBeginMemberEnd dd{};
+  assert(base(std::ranges::rbegin(d).base()) == &d.e);
+  assert(base(std::ranges::crbegin(d).base()) == &d.ce);
+  assert(base(std::ranges::rbegin(dd).base()) == &dd.ce);
+  assert(base(std::ranges::crbegin(dd).base()) == &dd.ce);
+
+  return true;
+}
+
+
+ASSERT_NOEXCEPT(std::ranges::rbegin(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(std::ranges::crbegin(std::declval<int (&)[10]>()));
+
+struct NoThrowMemberRBegin {
+  ThrowingIterator<int> rbegin() const noexcept; // auto(t.rbegin()) doesn't throw
+} ntmb;
+static_assert(noexcept(std::ranges::rbegin(ntmb)));
+static_assert(noexcept(std::ranges::crbegin(ntmb)));
+
+struct NoThrowADLRBegin {
+  friend ThrowingIterator<int> rbegin(NoThrowADLRBegin&) noexcept;  // auto(rbegin(t)) doesn't throw
+  friend ThrowingIterator<int> rbegin(const NoThrowADLRBegin&) noexcept;
+} ntab;
+static_assert(noexcept(std::ranges::rbegin(ntab)));
+static_assert(noexcept(std::ranges::crbegin(ntab)));
+
+struct NoThrowMemberRBeginReturnsRef {
+  ThrowingIterator<int>& rbegin() const noexcept; // auto(t.rbegin()) may throw
+} ntmbrr;
+static_assert(!noexcept(std::ranges::rbegin(ntmbrr)));
+static_assert(!noexcept(std::ranges::crbegin(ntmbrr)));
+
+struct RBeginReturnsArrayRef {
+    auto rbegin() const noexcept -> int(&)[10];
+} brar;
+static_assert(noexcept(std::ranges::rbegin(brar)));
+static_assert(noexcept(std::ranges::crbegin(brar)));
+
+struct NoThrowBeginThrowingEnd {
+  int* begin() const noexcept;
+  int* end() const;
+} ntbte;
+static_assert(!noexcept(std::ranges::rbegin(ntbte)));
+static_assert(!noexcept(std::ranges::crbegin(ntbte)));
+
+struct NoThrowEndThrowingBegin {
+  int* begin() const;
+  int* end() const noexcept;
+} ntetb;
+static_assert(noexcept(std::ranges::rbegin(ntetb)));
+static_assert(noexcept(std::ranges::crbegin(ntetb)));
+
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(!std::is_invocable_v<RangeRBeginT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeRBeginT, Holder<Incomplete>*&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Holder<Incomplete>*&>);
+
+int main(int, char**) {
+  static_assert(testReturnTypes());
+
+  testArray();
+  static_assert(testArray());
+
+  testRBeginMember();
+  static_assert(testRBeginMember());
+
+  testRBeginFunction();
+  static_assert(testRBeginFunction());
+
+  testBeginEnd();
+  static_assert(testBeginEnd());
+
+  return 0;
+}

--- a/llvm/access/rbegin.pass.cpp
+++ b/llvm/access/rbegin.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -8,514 +11,594 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::rbegin
-// std::ranges::crbegin
+// xranges::rbegin
+// xranges::crbegin
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
 
 #include <cassert>
 #include <utility>
-#include "test_macros.h"
-#include "test_iterators.h"
 
-using RangeRBeginT = decltype(std::ranges::rbegin);
-using RangeCRBeginT = decltype(std::ranges::crbegin);
+using RangeRBeginT = decltype(xranges::rbegin);
+using RangeCRBeginT = decltype(xranges::crbegin);
 
 static int globalBuff[8];
 
 static_assert(!std::is_invocable_v<RangeRBeginT, int (&&)[10]>);
-static_assert( std::is_invocable_v<RangeRBeginT, int (&)[10]>);
+static_assert(std::is_invocable_v<RangeRBeginT, int (&)[10]>);
 static_assert(!std::is_invocable_v<RangeRBeginT, int (&&)[]>);
 static_assert(!std::is_invocable_v<RangeRBeginT, int (&)[]>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, int (&&)[10]>);
-static_assert( std::is_invocable_v<RangeCRBeginT, int (&)[10]>);
+static_assert(std::is_invocable_v<RangeCRBeginT, int (&)[10]>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, int (&&)[]>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, int (&)[]>);
 
 struct Incomplete;
 
-static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete(&&)[]>);
-static_assert(!std::is_invocable_v<RangeRBeginT, const Incomplete(&&)[]>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete(&&)[]>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, const Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete (&&)[]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete const (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete const (&&)[]>);
 
-static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete(&&)[10]>);
-static_assert(!std::is_invocable_v<RangeRBeginT, const Incomplete(&&)[10]>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete(&&)[10]>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, const Incomplete(&&)[10]>);
-
-// This case is IFNDR; we handle it SFINAE-friendly.
-LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeRBeginT, Incomplete(&)[]>);
-LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeRBeginT, const Incomplete(&)[]>);
-LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCRBeginT, Incomplete(&)[]>);
-LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCRBeginT, const Incomplete(&)[]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete (&&)[10]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete const (&&)[10]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete (&&)[10]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete const (&&)[10]>);
 
 // This case is IFNDR; we handle it SFINAE-friendly.
-LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeRBeginT, Incomplete(&)[10]>);
-LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeRBeginT, const Incomplete(&)[10]>);
-LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCRBeginT, Incomplete(&)[10]>);
-LIBCPP_STATIC_ASSERT(!std::is_invocable_v<RangeCRBeginT, const Incomplete(&)[10]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete (&)[]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete const (&)[]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete (&)[]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete const (&)[]>);
+
+// This case is IFNDR; we handle it SFINAE-friendly.
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete (&)[10]>);
+static_assert(!std::is_invocable_v<RangeRBeginT, Incomplete const (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, Incomplete const (&)[10]>);
 
 struct RBeginMember {
-  int x;
-  constexpr const int *rbegin() const { return &x; }
+    int x;
+    constexpr int const* rbegin() const { return &x; }
 };
 
 // Ensure that we can't call with rvalues with borrowing disabled.
-static_assert( std::is_invocable_v<RangeRBeginT, RBeginMember &>);
-static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMember &&>);
-static_assert( std::is_invocable_v<RangeRBeginT, RBeginMember const&>);
+static_assert(std::is_invocable_v<RangeRBeginT, RBeginMember&>);
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMember&&>);
+static_assert(std::is_invocable_v<RangeRBeginT, RBeginMember const&>);
 static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMember const&&>);
-static_assert( std::is_invocable_v<RangeCRBeginT, RBeginMember &>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginMember &&>);
-static_assert( std::is_invocable_v<RangeCRBeginT, RBeginMember const&>);
+static_assert(std::is_invocable_v<RangeCRBeginT, RBeginMember&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginMember&&>);
+static_assert(std::is_invocable_v<RangeCRBeginT, RBeginMember const&>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginMember const&&>);
 
 constexpr bool testReturnTypes() {
-  {
-    int *x[2];
-    ASSERT_SAME_TYPE(decltype(std::ranges::rbegin(x)), std::reverse_iterator<int**>);
-    ASSERT_SAME_TYPE(decltype(std::ranges::crbegin(x)), std::reverse_iterator<int* const*>);
-  }
-  {
-    int x[2][2];
-    ASSERT_SAME_TYPE(decltype(std::ranges::rbegin(x)), std::reverse_iterator<int(*)[2]>);
-    ASSERT_SAME_TYPE(decltype(std::ranges::crbegin(x)), std::reverse_iterator<const int(*)[2]>);
-  }
-  {
-    struct Different {
-      char*& rbegin();
-      short*& rbegin() const;
-    } x;
-    ASSERT_SAME_TYPE(decltype(std::ranges::rbegin(x)), char*);
-    ASSERT_SAME_TYPE(decltype(std::ranges::crbegin(x)), short*);
-  }
-  return true;
+    {
+        int* x[2];
+        ASSERT_SAME_TYPE(
+            decltype(xranges::rbegin(x)), std::reverse_iterator<int**>);
+        ASSERT_SAME_TYPE(
+            decltype(xranges::crbegin(x)), std::reverse_iterator<int* const*>);
+    }
+    {
+        int x[2][2];
+        ASSERT_SAME_TYPE(
+            decltype(xranges::rbegin(x)), std::reverse_iterator<int(*)[2]>);
+        ASSERT_SAME_TYPE(decltype(xranges::crbegin(x)),
+            std::reverse_iterator<int const(*)[2]>);
+    }
+    {
+        struct Different {
+            char*& rbegin();
+            short*& rbegin() const;
+        } x;
+        ASSERT_SAME_TYPE(decltype(xranges::rbegin(x)), char*);
+        ASSERT_SAME_TYPE(decltype(xranges::crbegin(x)), short*);
+    }
+    return true;
 }
 
 constexpr bool testArray() {
-  int a[2];
-  assert(std::ranges::rbegin(a).base() == a + 2);
-  assert(std::ranges::crbegin(a).base() == a + 2);
+    int a[2];
+    assert(xranges::rbegin(a).base() == a + 2);
+    assert(xranges::crbegin(a).base() == a + 2);
 
-  int b[2][2];
-  assert(std::ranges::rbegin(b).base() == b + 2);
-  assert(std::ranges::crbegin(b).base() == b + 2);
+    int b[2][2];
+    assert(xranges::rbegin(b).base() == b + 2);
+    assert(xranges::crbegin(b).base() == b + 2);
 
-  RBeginMember c[2];
-  assert(std::ranges::rbegin(c).base() == c + 2);
-  assert(std::ranges::crbegin(c).base() == c + 2);
+    RBeginMember c[2];
+    assert(xranges::rbegin(c).base() == c + 2);
+    assert(xranges::crbegin(c).base() == c + 2);
 
-  return true;
+    return true;
 }
 
 struct RBeginMemberReturnsInt {
-  int rbegin() const;
+    int rbegin() const;
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMemberReturnsInt const&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, RBeginMemberReturnsInt const&>);
 
 struct RBeginMemberReturnsVoidPtr {
-  const void *rbegin() const;
+    void const* rbegin() const;
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMemberReturnsVoidPtr const&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, RBeginMemberReturnsVoidPtr const&>);
 
 struct PtrConvertibleRBeginMember {
-  struct iterator { operator int*() const; };
-  iterator rbegin() const;
+    struct iterator {
+        operator int*() const;
+    };
+    iterator rbegin() const;
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, PtrConvertibleRBeginMember const&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, PtrConvertibleRBeginMember const&>);
 
 struct NonConstRBeginMember {
-  int x;
-  constexpr int* rbegin() { return &x; }
+    int x;
+    constexpr int* rbegin() { return &x; }
 };
-static_assert( std::is_invocable_v<RangeRBeginT,  NonConstRBeginMember &>);
-static_assert(!std::is_invocable_v<RangeRBeginT,  NonConstRBeginMember const&>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, NonConstRBeginMember &>);
+static_assert(std::is_invocable_v<RangeRBeginT, NonConstRBeginMember&>);
+static_assert(!std::is_invocable_v<RangeRBeginT, NonConstRBeginMember const&>);
+static_assert(!std::is_invocable_v<RangeCRBeginT, NonConstRBeginMember&>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, NonConstRBeginMember const&>);
 
 struct EnabledBorrowingRBeginMember {
-  constexpr int *rbegin() const { return globalBuff; }
+    constexpr int* rbegin() const { return globalBuff; }
 };
-template<>
-inline constexpr bool std::ranges::enable_borrowed_range<EnabledBorrowingRBeginMember> = true;
+template <>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<EnabledBorrowingRBeginMember> = true;
 
 struct RBeginMemberFunction {
-  int x;
-  constexpr const int *rbegin() const { return &x; }
-  friend int* rbegin(RBeginMemberFunction const&);
+    int x;
+    constexpr int const* rbegin() const { return &x; }
+    friend int* rbegin(RBeginMemberFunction const&);
 };
 
 struct EmptyPtrRBeginMember {
-  struct Empty {};
-  Empty x;
-  constexpr const Empty* rbegin() const { return &x; }
+    struct Empty {};
+    Empty x;
+    constexpr Empty const* rbegin() const { return &x; }
 };
 
 constexpr bool testRBeginMember() {
-  RBeginMember a;
-  assert(std::ranges::rbegin(a) == &a.x);
-  assert(std::ranges::crbegin(a) == &a.x);
-  static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMember&&>);
-  static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginMember&&>);
+    RBeginMember a;
+    assert(xranges::rbegin(a) == &a.x);
+    assert(xranges::crbegin(a) == &a.x);
+    static_assert(!std::is_invocable_v<RangeRBeginT, RBeginMember&&>);
+    static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginMember&&>);
 
-  NonConstRBeginMember b;
-  assert(std::ranges::rbegin(b) == &b.x);
-  static_assert(!std::is_invocable_v<RangeCRBeginT, NonConstRBeginMember&>);
+    NonConstRBeginMember b;
+    assert(xranges::rbegin(b) == &b.x);
+    static_assert(!std::is_invocable_v<RangeCRBeginT, NonConstRBeginMember&>);
 
-  EnabledBorrowingRBeginMember c;
-  assert(std::ranges::rbegin(c) == globalBuff);
-  assert(std::ranges::crbegin(c) == globalBuff);
-  assert(std::ranges::rbegin(std::move(c)) == globalBuff);
-  assert(std::ranges::crbegin(std::move(c)) == globalBuff);
+    EnabledBorrowingRBeginMember c;
+    assert(xranges::rbegin(c) == globalBuff);
+    assert(xranges::crbegin(c) == globalBuff);
+    assert(xranges::rbegin(std::move(c)) == globalBuff);
+    assert(xranges::crbegin(std::move(c)) == globalBuff);
 
-  RBeginMemberFunction d;
-  assert(std::ranges::rbegin(d) == &d.x);
-  assert(std::ranges::crbegin(d) == &d.x);
+    RBeginMemberFunction d;
+    assert(xranges::rbegin(d) == &d.x);
+    assert(xranges::crbegin(d) == &d.x);
 
-  EmptyPtrRBeginMember e;
-  assert(std::ranges::rbegin(e) == &e.x);
-  assert(std::ranges::crbegin(e) == &e.x);
+    EmptyPtrRBeginMember e;
+    assert(xranges::rbegin(e) == &e.x);
+    assert(xranges::crbegin(e) == &e.x);
 
-  return true;
+    return true;
 }
 
-
 struct RBeginFunction {
-  int x;
-  friend constexpr const int* rbegin(RBeginFunction const& bf) { return &bf.x; }
+    int x;
+    friend constexpr int const* rbegin(RBeginFunction const& bf) {
+        return &bf.x;
+    }
 };
-static_assert( std::is_invocable_v<RangeRBeginT,  RBeginFunction const&>);
-static_assert(!std::is_invocable_v<RangeRBeginT,  RBeginFunction &&>);
-static_assert(
-    std::is_invocable_v<RangeRBeginT, RBeginFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-static_assert( std::is_invocable_v<RangeCRBeginT, RBeginFunction const&>);
-static_assert( std::is_invocable_v<RangeCRBeginT, RBeginFunction &>);
+static_assert(std::is_invocable_v<RangeRBeginT, RBeginFunction const&>);
+static_assert(!std::is_invocable_v<RangeRBeginT, RBeginFunction&&>);
+static_assert(std::is_invocable_v<RangeRBeginT,
+    RBeginFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+static_assert(std::is_invocable_v<RangeCRBeginT, RBeginFunction const&>);
+static_assert(std::is_invocable_v<RangeCRBeginT, RBeginFunction&>);
 
 struct RBeginFunctionReturnsInt {
-  friend int rbegin(RBeginFunctionReturnsInt const&);
+    friend int rbegin(RBeginFunctionReturnsInt const&);
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsInt const&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsInt const&>);
 
 struct RBeginFunctionReturnsVoidPtr {
-  friend void *rbegin(RBeginFunctionReturnsVoidPtr const&);
+    friend void* rbegin(RBeginFunctionReturnsVoidPtr const&);
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsVoidPtr const&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsVoidPtr const&>);
 
 struct RBeginFunctionReturnsEmpty {
-  struct Empty {};
-  friend Empty rbegin(RBeginFunctionReturnsEmpty const&);
+    struct Empty {};
+    friend Empty rbegin(RBeginFunctionReturnsEmpty const&);
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsEmpty const&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsEmpty const&>);
 
 struct RBeginFunctionReturnsPtrConvertible {
-  struct iterator { operator int*() const; };
-  friend iterator rbegin(RBeginFunctionReturnsPtrConvertible const&);
+    struct iterator {
+        operator int*() const;
+    };
+    friend iterator rbegin(RBeginFunctionReturnsPtrConvertible const&);
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, RBeginFunctionReturnsPtrConvertible const&>);
+static_assert(!std::is_invocable_v<RangeRBeginT,
+              RBeginFunctionReturnsPtrConvertible const&>);
 
 struct RBeginFunctionByValue {
-  friend constexpr int *rbegin(RBeginFunctionByValue) { return globalBuff + 1; }
+    friend constexpr int* rbegin(RBeginFunctionByValue) {
+        return globalBuff + 1;
+    }
 };
 static_assert(!std::is_invocable_v<RangeCRBeginT, RBeginFunctionByValue>);
 
 struct RBeginFunctionEnabledBorrowing {
-  friend constexpr int *rbegin(RBeginFunctionEnabledBorrowing) { return globalBuff + 2; }
+    friend constexpr int* rbegin(RBeginFunctionEnabledBorrowing) {
+        return globalBuff + 2;
+    }
 };
-template<>
-inline constexpr bool std::ranges::enable_borrowed_range<RBeginFunctionEnabledBorrowing> = true;
+template <>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<RBeginFunctionEnabledBorrowing> = true;
 
 struct RBeginFunctionReturnsEmptyPtr {
-  struct Empty {};
-  Empty x;
-  friend constexpr const Empty *rbegin(RBeginFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+    struct Empty {};
+    Empty x;
+    friend constexpr Empty const* rbegin(
+        RBeginFunctionReturnsEmptyPtr const& bf) {
+        return &bf.x;
+    }
 };
 
 struct RBeginFunctionWithDataMember {
-  int x;
-  int rbegin;
-  friend constexpr const int *rbegin(RBeginFunctionWithDataMember const& bf) { return &bf.x; }
+    int x;
+    int rbegin;
+    friend constexpr int const* rbegin(RBeginFunctionWithDataMember const& bf) {
+        return &bf.x;
+    }
 };
 
 struct RBeginFunctionWithPrivateBeginMember {
-  int y;
-  friend constexpr const int *rbegin(RBeginFunctionWithPrivateBeginMember const& bf) { return &bf.y; }
+    int y;
+    friend constexpr int const* rbegin(
+        RBeginFunctionWithPrivateBeginMember const& bf) {
+        return &bf.y;
+    }
+
 private:
-  const int *rbegin() const;
+    int const* rbegin() const;
 };
 
 constexpr bool testRBeginFunction() {
-  RBeginFunction a{};
-  const RBeginFunction aa{};
-  assert(std::ranges::rbegin(a) == &a.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::crbegin(a) == &a.x);
-  assert(std::ranges::rbegin(aa) == &aa.x);
-  assert(std::ranges::crbegin(aa) == &aa.x);
+    RBeginFunction a{};
+    RBeginFunction const aa{};
+    assert(xranges::rbegin(a) ==
+        &a.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::crbegin(a) == &a.x);
+    assert(xranges::rbegin(aa) == &aa.x);
+    assert(xranges::crbegin(aa) == &aa.x);
 
-  RBeginFunctionByValue b{};
-  const RBeginFunctionByValue bb{};
-  assert(std::ranges::rbegin(b) == globalBuff + 1);
-  assert(std::ranges::crbegin(b) == globalBuff + 1);
-  assert(std::ranges::rbegin(bb) == globalBuff + 1);
-  assert(std::ranges::crbegin(bb) == globalBuff + 1);
+    RBeginFunctionByValue b{};
+    RBeginFunctionByValue const bb{};
+    assert(xranges::rbegin(b) == globalBuff + 1);
+    assert(xranges::crbegin(b) == globalBuff + 1);
+    assert(xranges::rbegin(bb) == globalBuff + 1);
+    assert(xranges::crbegin(bb) == globalBuff + 1);
 
-  RBeginFunctionEnabledBorrowing c{};
-  const RBeginFunctionEnabledBorrowing cc{};
-  assert(std::ranges::rbegin(std::move(c)) == globalBuff + 2);
-  assert(std::ranges::crbegin(std::move(c)) == globalBuff + 2);
-  assert(std::ranges::rbegin(std::move(cc)) == globalBuff + 2);
-  assert(std::ranges::crbegin(std::move(cc)) == globalBuff + 2);
+    RBeginFunctionEnabledBorrowing c{};
+    RBeginFunctionEnabledBorrowing const cc{};
+    assert(xranges::rbegin(std::move(c)) == globalBuff + 2);
+    assert(xranges::crbegin(std::move(c)) == globalBuff + 2);
+    assert(xranges::rbegin(std::move(cc)) == globalBuff + 2);
+    assert(xranges::crbegin(std::move(cc)) == globalBuff + 2);
 
-  RBeginFunctionReturnsEmptyPtr d{};
-  const RBeginFunctionReturnsEmptyPtr dd{};
-  assert(std::ranges::rbegin(d) == &d.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::crbegin(d) == &d.x);
-  assert(std::ranges::rbegin(dd) == &dd.x);
-  assert(std::ranges::crbegin(dd) == &dd.x);
+    RBeginFunctionReturnsEmptyPtr d{};
+    RBeginFunctionReturnsEmptyPtr const dd{};
+    assert(xranges::rbegin(d) ==
+        &d.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::crbegin(d) == &d.x);
+    assert(xranges::rbegin(dd) == &dd.x);
+    assert(xranges::crbegin(dd) == &dd.x);
 
-  RBeginFunctionWithDataMember e{};
-  const RBeginFunctionWithDataMember ee{};
-  assert(std::ranges::rbegin(e) == &e.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::rbegin(ee) == &ee.x);
-  assert(std::ranges::crbegin(e) == &e.x);
-  assert(std::ranges::crbegin(ee) == &ee.x);
+    RBeginFunctionWithDataMember e{};
+    RBeginFunctionWithDataMember const ee{};
+    assert(xranges::rbegin(e) ==
+        &e.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::rbegin(ee) == &ee.x);
+    assert(xranges::crbegin(e) == &e.x);
+    assert(xranges::crbegin(ee) == &ee.x);
 
-  RBeginFunctionWithPrivateBeginMember f{};
-  const RBeginFunctionWithPrivateBeginMember ff{};
-  assert(std::ranges::rbegin(f) == &f.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::crbegin(f) == &f.y);
-  assert(std::ranges::rbegin(ff) == &ff.y);
-  assert(std::ranges::crbegin(ff) == &ff.y);
+    RBeginFunctionWithPrivateBeginMember f{};
+    RBeginFunctionWithPrivateBeginMember const ff{};
+    assert(xranges::rbegin(f) ==
+        &f.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::crbegin(f) == &f.y);
+    assert(xranges::rbegin(ff) == &ff.y);
+    assert(xranges::crbegin(ff) == &ff.y);
 
-  return true;
+    return true;
 }
 
-
 struct MemberBeginEnd {
-  int b, e;
-  char cb, ce;
-  constexpr bidirectional_iterator<int*> begin() { return bidirectional_iterator<int*>(&b); }
-  constexpr bidirectional_iterator<int*> end() { return bidirectional_iterator<int*>(&e); }
-  constexpr bidirectional_iterator<const char*> begin() const { return bidirectional_iterator<const char*>(&cb); }
-  constexpr bidirectional_iterator<const char*> end() const { return bidirectional_iterator<const char*>(&ce); }
+    int b, e;
+    char cb, ce;
+    constexpr bidirectional_iterator<int*> begin() {
+        return bidirectional_iterator<int*>(&b);
+    }
+    constexpr bidirectional_iterator<int*> end() {
+        return bidirectional_iterator<int*>(&e);
+    }
+    constexpr bidirectional_iterator<char const*> begin() const {
+        return bidirectional_iterator<char const*>(&cb);
+    }
+    constexpr bidirectional_iterator<char const*> end() const {
+        return bidirectional_iterator<char const*>(&ce);
+    }
 };
-static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginEnd&>);
-static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginEnd const&>);
-static_assert( std::is_invocable_v<RangeCRBeginT, MemberBeginEnd const&>);
+static_assert(std::is_invocable_v<RangeRBeginT, MemberBeginEnd&>);
+static_assert(std::is_invocable_v<RangeRBeginT, MemberBeginEnd const&>);
+static_assert(std::is_invocable_v<RangeCRBeginT, MemberBeginEnd const&>);
 
 struct FunctionBeginEnd {
-  int b, e;
-  char cb, ce;
-  friend constexpr bidirectional_iterator<int*> begin(FunctionBeginEnd& v) {
-    return bidirectional_iterator<int*>(&v.b);
-  }
-  friend constexpr bidirectional_iterator<int*> end(FunctionBeginEnd& v) { return bidirectional_iterator<int*>(&v.e); }
-  friend constexpr bidirectional_iterator<const char*> begin(const FunctionBeginEnd& v) {
-    return bidirectional_iterator<const char*>(&v.cb);
-  }
-  friend constexpr bidirectional_iterator<const char*> end(const FunctionBeginEnd& v) {
-    return bidirectional_iterator<const char*>(&v.ce);
-  }
+    int b, e;
+    char cb, ce;
+    friend constexpr bidirectional_iterator<int*> begin(FunctionBeginEnd& v) {
+        return bidirectional_iterator<int*>(&v.b);
+    }
+    friend constexpr bidirectional_iterator<int*> end(FunctionBeginEnd& v) {
+        return bidirectional_iterator<int*>(&v.e);
+    }
+    friend constexpr bidirectional_iterator<char const*> begin(
+        FunctionBeginEnd const& v) {
+        return bidirectional_iterator<char const*>(&v.cb);
+    }
+    friend constexpr bidirectional_iterator<char const*> end(
+        FunctionBeginEnd const& v) {
+        return bidirectional_iterator<char const*>(&v.ce);
+    }
 };
-static_assert( std::is_invocable_v<RangeRBeginT, FunctionBeginEnd&>);
-static_assert( std::is_invocable_v<RangeRBeginT, FunctionBeginEnd const&>);
-static_assert( std::is_invocable_v<RangeCRBeginT, FunctionBeginEnd const&>);
+static_assert(std::is_invocable_v<RangeRBeginT, FunctionBeginEnd&>);
+static_assert(std::is_invocable_v<RangeRBeginT, FunctionBeginEnd const&>);
+static_assert(std::is_invocable_v<RangeCRBeginT, FunctionBeginEnd const&>);
 
 struct MemberBeginFunctionEnd {
-  int b, e;
-  char cb, ce;
-  constexpr bidirectional_iterator<int*> begin() { return bidirectional_iterator<int*>(&b); }
-  friend constexpr bidirectional_iterator<int*> end(MemberBeginFunctionEnd& v) {
-    return bidirectional_iterator<int*>(&v.e);
-  }
-  constexpr bidirectional_iterator<const char*> begin() const { return bidirectional_iterator<const char*>(&cb); }
-  friend constexpr bidirectional_iterator<const char*> end(const MemberBeginFunctionEnd& v) {
-    return bidirectional_iterator<const char*>(&v.ce);
-  }
+    int b, e;
+    char cb, ce;
+    constexpr bidirectional_iterator<int*> begin() {
+        return bidirectional_iterator<int*>(&b);
+    }
+    friend constexpr bidirectional_iterator<int*> end(
+        MemberBeginFunctionEnd& v) {
+        return bidirectional_iterator<int*>(&v.e);
+    }
+    constexpr bidirectional_iterator<char const*> begin() const {
+        return bidirectional_iterator<char const*>(&cb);
+    }
+    friend constexpr bidirectional_iterator<char const*> end(
+        MemberBeginFunctionEnd const& v) {
+        return bidirectional_iterator<char const*>(&v.ce);
+    }
 };
-static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginFunctionEnd&>);
-static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginFunctionEnd const&>);
-static_assert( std::is_invocable_v<RangeCRBeginT, MemberBeginFunctionEnd const&>);
+static_assert(std::is_invocable_v<RangeRBeginT, MemberBeginFunctionEnd&>);
+static_assert(std::is_invocable_v<RangeRBeginT, MemberBeginFunctionEnd const&>);
+static_assert(
+    std::is_invocable_v<RangeCRBeginT, MemberBeginFunctionEnd const&>);
 
 struct FunctionBeginMemberEnd {
-  int b, e;
-  char cb, ce;
-  friend constexpr bidirectional_iterator<int*> begin(FunctionBeginMemberEnd& v) {
-    return bidirectional_iterator<int*>(&v.b);
-  }
-  constexpr bidirectional_iterator<int*> end() { return bidirectional_iterator<int*>(&e); }
-  friend constexpr bidirectional_iterator<const char*> begin(const FunctionBeginMemberEnd& v) {
-    return bidirectional_iterator<const char*>(&v.cb);
-  }
-  constexpr bidirectional_iterator<const char*> end() const { return bidirectional_iterator<const char*>(&ce); }
+    int b, e;
+    char cb, ce;
+    friend constexpr bidirectional_iterator<int*> begin(
+        FunctionBeginMemberEnd& v) {
+        return bidirectional_iterator<int*>(&v.b);
+    }
+    constexpr bidirectional_iterator<int*> end() {
+        return bidirectional_iterator<int*>(&e);
+    }
+    friend constexpr bidirectional_iterator<char const*> begin(
+        FunctionBeginMemberEnd const& v) {
+        return bidirectional_iterator<char const*>(&v.cb);
+    }
+    constexpr bidirectional_iterator<char const*> end() const {
+        return bidirectional_iterator<char const*>(&ce);
+    }
 };
-static_assert( std::is_invocable_v<RangeRBeginT, FunctionBeginMemberEnd&>);
-static_assert( std::is_invocable_v<RangeRBeginT, FunctionBeginMemberEnd const&>);
-static_assert( std::is_invocable_v<RangeCRBeginT, FunctionBeginMemberEnd const&>);
+static_assert(std::is_invocable_v<RangeRBeginT, FunctionBeginMemberEnd&>);
+static_assert(std::is_invocable_v<RangeRBeginT, FunctionBeginMemberEnd const&>);
+static_assert(
+    std::is_invocable_v<RangeCRBeginT, FunctionBeginMemberEnd const&>);
 
 struct MemberBeginEndDifferentTypes {
-  bidirectional_iterator<int*> begin();
-  bidirectional_iterator<const int*> end();
+    bidirectional_iterator<int*> begin();
+    bidirectional_iterator<int const*> end();
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, MemberBeginEndDifferentTypes&>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, MemberBeginEndDifferentTypes&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, MemberBeginEndDifferentTypes&>);
+static_assert(
+    !std::is_invocable_v<RangeCRBeginT, MemberBeginEndDifferentTypes&>);
 
 struct FunctionBeginEndDifferentTypes {
-  friend bidirectional_iterator<int*> begin(FunctionBeginEndDifferentTypes&);
-  friend bidirectional_iterator<const int*> end(FunctionBeginEndDifferentTypes&);
+    friend bidirectional_iterator<int*> begin(FunctionBeginEndDifferentTypes&);
+    friend bidirectional_iterator<int const*> end(
+        FunctionBeginEndDifferentTypes&);
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, FunctionBeginEndDifferentTypes&>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, FunctionBeginEndDifferentTypes&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, FunctionBeginEndDifferentTypes&>);
+static_assert(
+    !std::is_invocable_v<RangeCRBeginT, FunctionBeginEndDifferentTypes&>);
 
 struct MemberBeginEndForwardIterators {
-  forward_iterator<int*> begin();
-  forward_iterator<int*> end();
+    forward_iterator<int*> begin();
+    forward_iterator<int*> end();
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, MemberBeginEndForwardIterators&>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, MemberBeginEndForwardIterators&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, MemberBeginEndForwardIterators&>);
+static_assert(
+    !std::is_invocable_v<RangeCRBeginT, MemberBeginEndForwardIterators&>);
 
 struct FunctionBeginEndForwardIterators {
-  friend forward_iterator<int*> begin(FunctionBeginEndForwardIterators&);
-  friend forward_iterator<int*> end(FunctionBeginEndForwardIterators&);
+    friend forward_iterator<int*> begin(FunctionBeginEndForwardIterators&);
+    friend forward_iterator<int*> end(FunctionBeginEndForwardIterators&);
 };
-static_assert(!std::is_invocable_v<RangeRBeginT, FunctionBeginEndForwardIterators&>);
-static_assert(!std::is_invocable_v<RangeCRBeginT, FunctionBeginEndForwardIterators&>);
+static_assert(
+    !std::is_invocable_v<RangeRBeginT, FunctionBeginEndForwardIterators&>);
+static_assert(
+    !std::is_invocable_v<RangeCRBeginT, FunctionBeginEndForwardIterators&>);
 
 struct MemberBeginOnly {
-  bidirectional_iterator<int*> begin() const;
+    bidirectional_iterator<int*> begin() const;
 };
 static_assert(!std::is_invocable_v<RangeRBeginT, MemberBeginOnly&>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, MemberBeginOnly&>);
 
 struct FunctionBeginOnly {
-  friend bidirectional_iterator<int*> begin(FunctionBeginOnly&);
+    friend bidirectional_iterator<int*> begin(FunctionBeginOnly&);
 };
 static_assert(!std::is_invocable_v<RangeRBeginT, FunctionBeginOnly&>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, FunctionBeginOnly&>);
 
 struct MemberEndOnly {
-  bidirectional_iterator<int*> end() const;
+    bidirectional_iterator<int*> end() const;
 };
 static_assert(!std::is_invocable_v<RangeRBeginT, MemberEndOnly&>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, MemberEndOnly&>);
 
 struct FunctionEndOnly {
-  friend bidirectional_iterator<int*> end(FunctionEndOnly&);
+    friend bidirectional_iterator<int*> end(FunctionEndOnly&);
 };
 static_assert(!std::is_invocable_v<RangeRBeginT, FunctionEndOnly&>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, FunctionEndOnly&>);
 
 // Make sure there is no clash between the following cases:
-// - the case that handles classes defining member `rbegin` and `rend` functions;
-// - the case that handles classes defining `begin` and `end` functions returning reversible iterators.
+// - the case that handles classes defining member `rbegin` and `rend`
+// functions;
+// - the case that handles classes defining `begin` and `end` functions
+// returning reversible iterators.
 struct MemberBeginAndRBegin {
-  int* begin() const;
-  int* end() const;
-  int* rbegin() const;
-  int* rend() const;
+    int* begin() const;
+    int* end() const;
+    int* rbegin() const;
+    int* rend() const;
 };
-static_assert( std::is_invocable_v<RangeRBeginT, MemberBeginAndRBegin&>);
-static_assert( std::is_invocable_v<RangeCRBeginT, MemberBeginAndRBegin&>);
-static_assert( std::same_as<std::invoke_result_t<RangeRBeginT, MemberBeginAndRBegin&>, int*>);
-static_assert( std::same_as<std::invoke_result_t<RangeCRBeginT, MemberBeginAndRBegin&>, int*>);
+static_assert(std::is_invocable_v<RangeRBeginT, MemberBeginAndRBegin&>);
+static_assert(std::is_invocable_v<RangeCRBeginT, MemberBeginAndRBegin&>);
+static_assert(
+    std::same_as<std::invoke_result_t<RangeRBeginT, MemberBeginAndRBegin&>,
+        int*>);
+static_assert(
+    std::same_as<std::invoke_result_t<RangeCRBeginT, MemberBeginAndRBegin&>,
+        int*>);
 
 constexpr bool testBeginEnd() {
-  MemberBeginEnd a{};
-  const MemberBeginEnd aa{};
-  assert(base(std::ranges::rbegin(a).base()) == &a.e);
-  assert(base(std::ranges::crbegin(a).base()) == &a.ce);
-  assert(base(std::ranges::rbegin(aa).base()) == &aa.ce);
-  assert(base(std::ranges::crbegin(aa).base()) == &aa.ce);
+    MemberBeginEnd a{};
+    MemberBeginEnd const aa{};
+    assert(base(xranges::rbegin(a).base()) == &a.e);
+    assert(base(xranges::crbegin(a).base()) == &a.ce);
+    assert(base(xranges::rbegin(aa).base()) == &aa.ce);
+    assert(base(xranges::crbegin(aa).base()) == &aa.ce);
 
-  FunctionBeginEnd b{};
-  const FunctionBeginEnd bb{};
-  assert(base(std::ranges::rbegin(b).base()) == &b.e);
-  assert(base(std::ranges::crbegin(b).base()) == &b.ce);
-  assert(base(std::ranges::rbegin(bb).base()) == &bb.ce);
-  assert(base(std::ranges::crbegin(bb).base()) == &bb.ce);
+    FunctionBeginEnd b{};
+    FunctionBeginEnd const bb{};
+    assert(base(xranges::rbegin(b).base()) == &b.e);
+    assert(base(xranges::crbegin(b).base()) == &b.ce);
+    assert(base(xranges::rbegin(bb).base()) == &bb.ce);
+    assert(base(xranges::crbegin(bb).base()) == &bb.ce);
 
-  MemberBeginFunctionEnd c{};
-  const MemberBeginFunctionEnd cc{};
-  assert(base(std::ranges::rbegin(c).base()) == &c.e);
-  assert(base(std::ranges::crbegin(c).base()) == &c.ce);
-  assert(base(std::ranges::rbegin(cc).base()) == &cc.ce);
-  assert(base(std::ranges::crbegin(cc).base()) == &cc.ce);
+    MemberBeginFunctionEnd c{};
+    MemberBeginFunctionEnd const cc{};
+    assert(base(xranges::rbegin(c).base()) == &c.e);
+    assert(base(xranges::crbegin(c).base()) == &c.ce);
+    assert(base(xranges::rbegin(cc).base()) == &cc.ce);
+    assert(base(xranges::crbegin(cc).base()) == &cc.ce);
 
-  FunctionBeginMemberEnd d{};
-  const FunctionBeginMemberEnd dd{};
-  assert(base(std::ranges::rbegin(d).base()) == &d.e);
-  assert(base(std::ranges::crbegin(d).base()) == &d.ce);
-  assert(base(std::ranges::rbegin(dd).base()) == &dd.ce);
-  assert(base(std::ranges::crbegin(dd).base()) == &dd.ce);
+    FunctionBeginMemberEnd d{};
+    FunctionBeginMemberEnd const dd{};
+    assert(base(xranges::rbegin(d).base()) == &d.e);
+    assert(base(xranges::crbegin(d).base()) == &d.ce);
+    assert(base(xranges::rbegin(dd).base()) == &dd.ce);
+    assert(base(xranges::crbegin(dd).base()) == &dd.ce);
 
-  return true;
+    return true;
 }
 
-
-ASSERT_NOEXCEPT(std::ranges::rbegin(std::declval<int (&)[10]>()));
-ASSERT_NOEXCEPT(std::ranges::crbegin(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(xranges::rbegin(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(xranges::crbegin(std::declval<int (&)[10]>()));
 
 struct NoThrowMemberRBegin {
-  ThrowingIterator<int> rbegin() const noexcept; // auto(t.rbegin()) doesn't throw
+    ThrowingIterator<int>
+    rbegin() const noexcept; // auto(t.rbegin()) doesn't throw
 } ntmb;
-static_assert(noexcept(std::ranges::rbegin(ntmb)));
-static_assert(noexcept(std::ranges::crbegin(ntmb)));
+static_assert(noexcept(xranges::rbegin(ntmb)));
+static_assert(noexcept(xranges::crbegin(ntmb)));
 
 struct NoThrowADLRBegin {
-  friend ThrowingIterator<int> rbegin(NoThrowADLRBegin&) noexcept;  // auto(rbegin(t)) doesn't throw
-  friend ThrowingIterator<int> rbegin(const NoThrowADLRBegin&) noexcept;
+    friend ThrowingIterator<int> rbegin(
+        NoThrowADLRBegin&) noexcept; // auto(rbegin(t)) doesn't throw
+    friend ThrowingIterator<int> rbegin(NoThrowADLRBegin const&) noexcept;
 } ntab;
-static_assert(noexcept(std::ranges::rbegin(ntab)));
-static_assert(noexcept(std::ranges::crbegin(ntab)));
+static_assert(noexcept(xranges::rbegin(ntab)));
+static_assert(noexcept(xranges::crbegin(ntab)));
 
 struct NoThrowMemberRBeginReturnsRef {
-  ThrowingIterator<int>& rbegin() const noexcept; // auto(t.rbegin()) may throw
+    ThrowingIterator<int>&
+    rbegin() const noexcept; // auto(t.rbegin()) may throw
 } ntmbrr;
-static_assert(!noexcept(std::ranges::rbegin(ntmbrr)));
-static_assert(!noexcept(std::ranges::crbegin(ntmbrr)));
+static_assert(!noexcept(xranges::rbegin(ntmbrr)));
+static_assert(!noexcept(xranges::crbegin(ntmbrr)));
 
 struct RBeginReturnsArrayRef {
-    auto rbegin() const noexcept -> int(&)[10];
+    auto rbegin() const noexcept -> int (&)[10];
 } brar;
-static_assert(noexcept(std::ranges::rbegin(brar)));
-static_assert(noexcept(std::ranges::crbegin(brar)));
+static_assert(noexcept(xranges::rbegin(brar)));
+static_assert(noexcept(xranges::crbegin(brar)));
 
 struct NoThrowBeginThrowingEnd {
-  int* begin() const noexcept;
-  int* end() const;
+    int* begin() const noexcept;
+    int* end() const;
 } ntbte;
-static_assert(!noexcept(std::ranges::rbegin(ntbte)));
-static_assert(!noexcept(std::ranges::crbegin(ntbte)));
+static_assert(!noexcept(xranges::rbegin(ntbte)));
+static_assert(!noexcept(xranges::crbegin(ntbte)));
 
 struct NoThrowEndThrowingBegin {
-  int* begin() const;
-  int* end() const noexcept;
+    int* begin() const;
+    int* end() const noexcept;
 } ntetb;
-static_assert(noexcept(std::ranges::rbegin(ntetb)));
-static_assert(noexcept(std::ranges::crbegin(ntetb)));
+static_assert(noexcept(xranges::rbegin(ntetb)));
+static_assert(noexcept(xranges::crbegin(ntetb)));
 
 // Test ADL-proofing.
 struct Incomplete;
-template<class T> struct Holder { T t; };
+template <class T>
+struct Holder {
+    T t;
+};
 static_assert(!std::is_invocable_v<RangeRBeginT, Holder<Incomplete>*>);
 static_assert(!std::is_invocable_v<RangeRBeginT, Holder<Incomplete>*&>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, Holder<Incomplete>*>);
 static_assert(!std::is_invocable_v<RangeCRBeginT, Holder<Incomplete>*&>);
 
 int main(int, char**) {
-  static_assert(testReturnTypes());
+    static_assert(testReturnTypes());
 
-  testArray();
-  static_assert(testArray());
+    testArray();
+    static_assert(testArray());
 
-  testRBeginMember();
-  static_assert(testRBeginMember());
+    testRBeginMember();
+    static_assert(testRBeginMember());
 
-  testRBeginFunction();
-  static_assert(testRBeginFunction());
+    testRBeginFunction();
+    static_assert(testRBeginFunction());
 
-  testBeginEnd();
-  static_assert(testBeginEnd());
+    testBeginEnd();
+    static_assert(testBeginEnd());
 
-  return 0;
+    return 0;
 }

--- a/llvm/access/rbegin.pass.cpp
+++ b/llvm/access/rbegin.pass.cpp
@@ -105,7 +105,8 @@ constexpr bool testReturnTypes() {
             short*& end() const;
         } x;
         ASSERT_SAME_TYPE(decltype(xranges::rbegin(x)), char*);
-        ASSERT_SAME_TYPE(decltype(xranges::crbegin(x)), short const*);
+        ASSERT_SAME_TYPE(
+            decltype(xranges::crbegin(x)), rxx::basic_const_iterator<short*>);
     }
     return true;
 }
@@ -563,7 +564,7 @@ static_assert(
         int*>);
 static_assert(
     std::same_as<std::invoke_result_t<RangeCRBeginT, MemberBeginAndRBegin&>,
-        int const*>);
+        rxx::basic_const_iterator<int*>>);
 
 constexpr bool testBeginEnd() {
     MemberBeginEnd a{};

--- a/llvm/access/rbegin.verify.cpp
+++ b/llvm/access/rbegin.verify.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::rbegin
+
+#include <ranges>
+
+struct NonBorrowedRange {
+  int* begin() const;
+  int* end() const;
+};
+static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
+
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::rbegin` is ill-formed.
+void test() {
+  std::ranges::rbegin(NonBorrowedRange());
+  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (std::ranges::)?__rbegin::__fn'}}}}
+  // expected-error@-2  {{attempt to use a deleted function}}
+}

--- a/llvm/access/rbegin.verify.cpp
+++ b/llvm/access/rbegin.verify.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/rbegin.verify.cpp
+++ b/llvm/access/rbegin.verify.cpp
@@ -11,19 +11,27 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::rbegin
+// rxx::ranges::rbegin
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
 
 struct NonBorrowedRange {
-  int* begin() const;
-  int* end() const;
+    int* begin() const;
+    int* end() const;
 };
 static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
 
-// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::rbegin` is ill-formed.
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is
+// false, `ranges::rbegin` is ill-formed.
 void test() {
-  std::ranges::rbegin(NonBorrowedRange());
-  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (std::ranges::)?__rbegin::__fn'}}}}
-  // expected-error@-2  {{attempt to use a deleted function}}
+    xranges::rbegin(NonBorrowedRange());
+    // clang-format off
+    // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (rxx::ranges::)?details::rbegin'}}}}
+    // expected-error@-2  {{attempt to use a deleted function}}
+    // clang-format on
 }

--- a/llvm/access/rend.pass.cpp
+++ b/llvm/access/rend.pass.cpp
@@ -1,0 +1,549 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::rend
+// std::ranges::crend
+
+#include <ranges>
+
+#include <cassert>
+#include <utility>
+#include "test_macros.h"
+#include "test_iterators.h"
+
+using RangeREndT = decltype(std::ranges::rend);
+using RangeCREndT = decltype(std::ranges::crend);
+
+static int globalBuff[8];
+
+static_assert(!std::is_invocable_v<RangeREndT, int (&&)[]>);
+static_assert(!std::is_invocable_v<RangeREndT, int (&)[]>);
+static_assert(!std::is_invocable_v<RangeREndT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeREndT, int (&)[10]>);
+static_assert(!std::is_invocable_v<RangeCREndT, int (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCREndT, int (&)[]>);
+static_assert(!std::is_invocable_v<RangeCREndT, int (&&)[10]>);
+static_assert( std::is_invocable_v<RangeCREndT, int (&)[10]>);
+
+struct Incomplete;
+static_assert(!std::is_invocable_v<RangeREndT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeREndT, Incomplete(&&)[42]>);
+static_assert(!std::is_invocable_v<RangeCREndT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeCREndT, Incomplete(&&)[42]>);
+
+struct REndMember {
+  int x;
+  const int* rbegin() const;
+  constexpr const int* rend() const { return &x; }
+};
+
+// Ensure that we can't call with rvalues with borrowing disabled.
+static_assert( std::is_invocable_v<RangeREndT, REndMember&>);
+static_assert(!std::is_invocable_v<RangeREndT, REndMember &&>);
+static_assert( std::is_invocable_v<RangeREndT, REndMember const&>);
+static_assert(!std::is_invocable_v<RangeREndT, REndMember const&&>);
+static_assert( std::is_invocable_v<RangeCREndT, REndMember &>);
+static_assert(!std::is_invocable_v<RangeCREndT, REndMember &&>);
+static_assert( std::is_invocable_v<RangeCREndT, REndMember const&>);
+static_assert(!std::is_invocable_v<RangeCREndT, REndMember const&&>);
+
+constexpr bool testReturnTypes() {
+  {
+    int *x[2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::rend(x)), std::reverse_iterator<int**>);
+    ASSERT_SAME_TYPE(decltype(std::ranges::crend(x)), std::reverse_iterator<int* const*>);
+  }
+
+  {
+    int x[2][2];
+    ASSERT_SAME_TYPE(decltype(std::ranges::rend(x)), std::reverse_iterator<int(*)[2]>);
+    ASSERT_SAME_TYPE(decltype(std::ranges::crend(x)), std::reverse_iterator<const int(*)[2]>);
+  }
+
+  {
+    struct Different {
+      char* rbegin();
+      sentinel_wrapper<char*>& rend();
+      short* rbegin() const;
+      sentinel_wrapper<short*>& rend() const;
+    } x;
+    ASSERT_SAME_TYPE(decltype(std::ranges::rend(x)), sentinel_wrapper<char*>);
+    ASSERT_SAME_TYPE(decltype(std::ranges::crend(x)), sentinel_wrapper<short*>);
+  }
+
+  return true;
+}
+
+constexpr bool testArray() {
+  int a[2];
+  assert(std::ranges::rend(a).base() == a);
+  assert(std::ranges::crend(a).base() == a);
+
+  int b[2][2];
+  assert(std::ranges::rend(b).base() == b);
+  assert(std::ranges::crend(b).base() == b);
+
+  REndMember c[2];
+  assert(std::ranges::rend(c).base() == c);
+  assert(std::ranges::crend(c).base() == c);
+
+  return true;
+}
+
+struct REndMemberReturnsInt {
+  int rbegin() const;
+  int rend() const;
+};
+static_assert(!std::is_invocable_v<RangeREndT, REndMemberReturnsInt const&>);
+
+struct REndMemberReturnsVoidPtr {
+  const void *rbegin() const;
+  const void *rend() const;
+};
+static_assert(!std::is_invocable_v<RangeREndT, REndMemberReturnsVoidPtr const&>);
+
+struct PtrConvertible {
+  operator int*() const;
+};
+struct PtrConvertibleREndMember {
+  PtrConvertible rbegin() const;
+  PtrConvertible rend() const;
+};
+static_assert(!std::is_invocable_v<RangeREndT, PtrConvertibleREndMember const&>);
+
+struct NoRBeginMember {
+  constexpr const int* rend();
+};
+static_assert(!std::is_invocable_v<RangeREndT, NoRBeginMember const&>);
+
+struct NonConstREndMember {
+  int x;
+  constexpr int* rbegin() { return nullptr; }
+  constexpr int* rend() { return &x; }
+};
+static_assert( std::is_invocable_v<RangeREndT,  NonConstREndMember &>);
+static_assert(!std::is_invocable_v<RangeREndT,  NonConstREndMember const&>);
+static_assert(!std::is_invocable_v<RangeCREndT, NonConstREndMember &>);
+static_assert(!std::is_invocable_v<RangeCREndT, NonConstREndMember const&>);
+
+struct EnabledBorrowingREndMember {
+  constexpr int* rbegin() const { return nullptr; }
+  constexpr int* rend() const { return &globalBuff[0]; }
+};
+
+template <>
+inline constexpr bool std::ranges::enable_borrowed_range<EnabledBorrowingREndMember> = true;
+
+struct REndMemberFunction {
+  int x;
+  constexpr const int* rbegin() const { return nullptr; }
+  constexpr const int* rend() const { return &x; }
+  friend constexpr int* rend(REndMemberFunction const&);
+};
+
+struct Empty { };
+struct EmptyEndMember {
+  Empty rbegin() const;
+  Empty rend() const;
+};
+static_assert(!std::is_invocable_v<RangeREndT, EmptyEndMember const&>);
+
+struct EmptyPtrREndMember {
+  Empty x;
+  constexpr const Empty* rbegin() const { return nullptr; }
+  constexpr const Empty* rend() const { return &x; }
+};
+
+constexpr bool testREndMember() {
+  REndMember a;
+  assert(std::ranges::rend(a) == &a.x);
+  assert(std::ranges::crend(a) == &a.x);
+
+  NonConstREndMember b;
+  assert(std::ranges::rend(b) == &b.x);
+  static_assert(!std::is_invocable_v<RangeCREndT, decltype((b))>);
+
+  EnabledBorrowingREndMember c;
+  assert(std::ranges::rend(std::move(c)) == &globalBuff[0]);
+  assert(std::ranges::crend(std::move(c)) == &globalBuff[0]);
+
+  REndMemberFunction d;
+  assert(std::ranges::rend(d) == &d.x);
+  assert(std::ranges::crend(d) == &d.x);
+
+  EmptyPtrREndMember e;
+  assert(std::ranges::rend(e) == &e.x);
+  assert(std::ranges::crend(e) == &e.x);
+
+  return true;
+}
+
+struct REndFunction {
+  int x;
+  friend constexpr const int* rbegin(REndFunction const&) { return nullptr; }
+  friend constexpr const int* rend(REndFunction const& bf) { return &bf.x; }
+};
+
+static_assert( std::is_invocable_v<RangeREndT, REndFunction const&>);
+static_assert(!std::is_invocable_v<RangeREndT, REndFunction &&>);
+
+static_assert( std::is_invocable_v<RangeREndT,  REndFunction const&>);
+static_assert(!std::is_invocable_v<RangeREndT,  REndFunction &&>);
+static_assert(std::is_invocable_v<RangeREndT, REndFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+static_assert( std::is_invocable_v<RangeCREndT, REndFunction const&>);
+static_assert( std::is_invocable_v<RangeCREndT, REndFunction &>);
+
+struct REndFunctionReturnsInt {
+  friend constexpr int rbegin(REndFunctionReturnsInt const&);
+  friend constexpr int rend(REndFunctionReturnsInt const&);
+};
+static_assert(!std::is_invocable_v<RangeREndT, REndFunctionReturnsInt const&>);
+
+struct REndFunctionReturnsVoidPtr {
+  friend constexpr void* rbegin(REndFunctionReturnsVoidPtr const&);
+  friend constexpr void* rend(REndFunctionReturnsVoidPtr const&);
+};
+static_assert(!std::is_invocable_v<RangeREndT, REndFunctionReturnsVoidPtr const&>);
+
+struct REndFunctionReturnsEmpty {
+  friend constexpr Empty rbegin(REndFunctionReturnsEmpty const&);
+  friend constexpr Empty rend(REndFunctionReturnsEmpty const&);
+};
+static_assert(!std::is_invocable_v<RangeREndT, REndFunctionReturnsEmpty const&>);
+
+struct REndFunctionReturnsPtrConvertible {
+  friend constexpr PtrConvertible rbegin(REndFunctionReturnsPtrConvertible const&);
+  friend constexpr PtrConvertible rend(REndFunctionReturnsPtrConvertible const&);
+};
+static_assert(!std::is_invocable_v<RangeREndT, REndFunctionReturnsPtrConvertible const&>);
+
+struct NoRBeginFunction {
+  friend constexpr const int* rend(NoRBeginFunction const&);
+};
+static_assert(!std::is_invocable_v<RangeREndT, NoRBeginFunction const&>);
+
+struct REndFunctionByValue {
+  friend constexpr int* rbegin(REndFunctionByValue) { return nullptr; }
+  friend constexpr int* rend(REndFunctionByValue) { return &globalBuff[1]; }
+};
+static_assert(!std::is_invocable_v<RangeCREndT, REndFunctionByValue>);
+
+struct REndFunctionEnabledBorrowing {
+  friend constexpr int* rbegin(REndFunctionEnabledBorrowing) { return nullptr; }
+  friend constexpr int* rend(REndFunctionEnabledBorrowing) { return &globalBuff[2]; }
+};
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<REndFunctionEnabledBorrowing> = true;
+
+struct REndFunctionReturnsEmptyPtr {
+  Empty x;
+  friend constexpr const Empty* rbegin(REndFunctionReturnsEmptyPtr const&) { return nullptr; }
+  friend constexpr const Empty* rend(REndFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+};
+
+struct REndFunctionWithDataMember {
+  int x;
+  int rend;
+  friend constexpr const int* rbegin(REndFunctionWithDataMember const&) { return nullptr; }
+  friend constexpr const int* rend(REndFunctionWithDataMember const& bf) { return &bf.x; }
+};
+
+struct REndFunctionWithPrivateEndMember : private REndMember {
+  int y;
+  friend constexpr const int* rbegin(REndFunctionWithPrivateEndMember const&) { return nullptr; }
+  friend constexpr const int* rend(REndFunctionWithPrivateEndMember const& bf) { return &bf.y; }
+};
+
+struct RBeginMemberEndFunction {
+  int x;
+  constexpr const int* rbegin() const { return nullptr; }
+  friend constexpr const int* rend(RBeginMemberEndFunction const& bf) { return &bf.x; }
+};
+
+constexpr bool testREndFunction() {
+  const REndFunction a{};
+  assert(std::ranges::rend(a) == &a.x);
+  assert(std::ranges::crend(a) == &a.x);
+  REndFunction aa{};
+  assert(std::ranges::rend(aa) == &aa.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::crend(aa) == &aa.x);
+
+  REndFunctionByValue b;
+  assert(std::ranges::rend(b) == &globalBuff[1]);
+  assert(std::ranges::crend(b) == &globalBuff[1]);
+
+  REndFunctionEnabledBorrowing c;
+  assert(std::ranges::rend(std::move(c)) == &globalBuff[2]);
+  assert(std::ranges::crend(std::move(c)) == &globalBuff[2]);
+
+  const REndFunctionReturnsEmptyPtr d{};
+  assert(std::ranges::rend(d) == &d.x);
+  assert(std::ranges::crend(d) == &d.x);
+  REndFunctionReturnsEmptyPtr dd{};
+  assert(std::ranges::rend(dd) == &dd.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::crend(dd) == &dd.x);
+
+  const REndFunctionWithDataMember e{};
+  assert(std::ranges::rend(e) == &e.x);
+  assert(std::ranges::crend(e) == &e.x);
+  REndFunctionWithDataMember ee{};
+  assert(std::ranges::rend(ee) == &ee.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::crend(ee) == &ee.x);
+
+  const REndFunctionWithPrivateEndMember f{};
+  assert(std::ranges::rend(f) == &f.y);
+  assert(std::ranges::crend(f) == &f.y);
+  REndFunctionWithPrivateEndMember ff{};
+  assert(std::ranges::rend(ff) == &ff.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::crend(ff) == &ff.y);
+
+  const RBeginMemberEndFunction g{};
+  assert(std::ranges::rend(g) == &g.x);
+  assert(std::ranges::crend(g) == &g.x);
+  RBeginMemberEndFunction gg{};
+  assert(std::ranges::rend(gg) == &gg.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+  assert(std::ranges::crend(gg) == &gg.x);
+
+  return true;
+}
+
+
+struct MemberBeginEnd {
+  int b, e;
+  char cb, ce;
+  constexpr bidirectional_iterator<int*> begin() { return bidirectional_iterator<int*>(&b); }
+  constexpr bidirectional_iterator<int*> end() { return bidirectional_iterator<int*>(&e); }
+  constexpr bidirectional_iterator<const char*> begin() const { return bidirectional_iterator<const char*>(&cb); }
+  constexpr bidirectional_iterator<const char*> end() const { return bidirectional_iterator<const char*>(&ce); }
+};
+static_assert( std::is_invocable_v<RangeREndT, MemberBeginEnd&>);
+static_assert( std::is_invocable_v<RangeREndT, MemberBeginEnd const&>);
+static_assert( std::is_invocable_v<RangeCREndT, MemberBeginEnd const&>);
+
+struct FunctionBeginEnd {
+  int b, e;
+  char cb, ce;
+  friend constexpr bidirectional_iterator<int*> begin(FunctionBeginEnd& v) {
+    return bidirectional_iterator<int*>(&v.b);
+  }
+  friend constexpr bidirectional_iterator<int*> end(FunctionBeginEnd& v) { return bidirectional_iterator<int*>(&v.e); }
+  friend constexpr bidirectional_iterator<const char*> begin(const FunctionBeginEnd& v) {
+    return bidirectional_iterator<const char*>(&v.cb);
+  }
+  friend constexpr bidirectional_iterator<const char*> end(const FunctionBeginEnd& v) {
+    return bidirectional_iterator<const char*>(&v.ce);
+  }
+};
+static_assert( std::is_invocable_v<RangeREndT, FunctionBeginEnd&>);
+static_assert( std::is_invocable_v<RangeREndT, FunctionBeginEnd const&>);
+static_assert( std::is_invocable_v<RangeCREndT, FunctionBeginEnd const&>);
+
+struct MemberBeginFunctionEnd {
+  int b, e;
+  char cb, ce;
+  constexpr bidirectional_iterator<int*> begin() { return bidirectional_iterator<int*>(&b); }
+  friend constexpr bidirectional_iterator<int*> end(MemberBeginFunctionEnd& v) {
+    return bidirectional_iterator<int*>(&v.e);
+  }
+  constexpr bidirectional_iterator<const char*> begin() const { return bidirectional_iterator<const char*>(&cb); }
+  friend constexpr bidirectional_iterator<const char*> end(const MemberBeginFunctionEnd& v) {
+    return bidirectional_iterator<const char*>(&v.ce);
+  }
+};
+static_assert( std::is_invocable_v<RangeREndT, MemberBeginFunctionEnd&>);
+static_assert( std::is_invocable_v<RangeREndT, MemberBeginFunctionEnd const&>);
+static_assert( std::is_invocable_v<RangeCREndT, MemberBeginFunctionEnd const&>);
+
+struct FunctionBeginMemberEnd {
+  int b, e;
+  char cb, ce;
+  friend constexpr bidirectional_iterator<int*> begin(FunctionBeginMemberEnd& v) {
+    return bidirectional_iterator<int*>(&v.b);
+  }
+  constexpr bidirectional_iterator<int*> end() { return bidirectional_iterator<int*>(&e); }
+  friend constexpr bidirectional_iterator<const char*> begin(const FunctionBeginMemberEnd& v) {
+    return bidirectional_iterator<const char*>(&v.cb);
+  }
+  constexpr bidirectional_iterator<const char*> end() const { return bidirectional_iterator<const char*>(&ce); }
+};
+static_assert( std::is_invocable_v<RangeREndT, FunctionBeginMemberEnd&>);
+static_assert( std::is_invocable_v<RangeREndT, FunctionBeginMemberEnd const&>);
+static_assert( std::is_invocable_v<RangeCREndT, FunctionBeginMemberEnd const&>);
+
+struct MemberBeginEndDifferentTypes {
+  bidirectional_iterator<int*> begin();
+  bidirectional_iterator<const int*> end();
+};
+static_assert(!std::is_invocable_v<RangeREndT, MemberBeginEndDifferentTypes&>);
+static_assert(!std::is_invocable_v<RangeCREndT, MemberBeginEndDifferentTypes&>);
+
+struct FunctionBeginEndDifferentTypes {
+  friend bidirectional_iterator<int*> begin(FunctionBeginEndDifferentTypes&);
+  friend bidirectional_iterator<const int*> end(FunctionBeginEndDifferentTypes&);
+};
+static_assert(!std::is_invocable_v<RangeREndT, FunctionBeginEndDifferentTypes&>);
+static_assert(!std::is_invocable_v<RangeCREndT, FunctionBeginEndDifferentTypes&>);
+
+struct MemberBeginEndForwardIterators {
+  forward_iterator<int*> begin();
+  forward_iterator<int*> end();
+};
+static_assert(!std::is_invocable_v<RangeREndT, MemberBeginEndForwardIterators&>);
+static_assert(!std::is_invocable_v<RangeCREndT, MemberBeginEndForwardIterators&>);
+
+struct FunctionBeginEndForwardIterators {
+  friend forward_iterator<int*> begin(FunctionBeginEndForwardIterators&);
+  friend forward_iterator<int*> end(FunctionBeginEndForwardIterators&);
+};
+static_assert(!std::is_invocable_v<RangeREndT, FunctionBeginEndForwardIterators&>);
+static_assert(!std::is_invocable_v<RangeCREndT, FunctionBeginEndForwardIterators&>);
+
+struct MemberBeginOnly {
+  bidirectional_iterator<int*> begin() const;
+};
+static_assert(!std::is_invocable_v<RangeREndT, MemberBeginOnly&>);
+static_assert(!std::is_invocable_v<RangeCREndT, MemberBeginOnly&>);
+
+struct FunctionBeginOnly {
+  friend bidirectional_iterator<int*> begin(FunctionBeginOnly&);
+};
+static_assert(!std::is_invocable_v<RangeREndT, FunctionBeginOnly&>);
+static_assert(!std::is_invocable_v<RangeCREndT, FunctionBeginOnly&>);
+
+struct MemberEndOnly {
+  bidirectional_iterator<int*> end() const;
+};
+static_assert(!std::is_invocable_v<RangeREndT, MemberEndOnly&>);
+static_assert(!std::is_invocable_v<RangeCREndT, MemberEndOnly&>);
+
+struct FunctionEndOnly {
+  friend bidirectional_iterator<int*> end(FunctionEndOnly&);
+};
+static_assert(!std::is_invocable_v<RangeREndT, FunctionEndOnly&>);
+static_assert(!std::is_invocable_v<RangeCREndT, FunctionEndOnly&>);
+
+// Make sure there is no clash between the following cases:
+// - the case that handles classes defining member `rbegin` and `rend` functions;
+// - the case that handles classes defining `begin` and `end` functions returning reversible iterators.
+struct MemberBeginAndRBegin {
+  int* begin() const;
+  int* end() const;
+  int* rbegin() const;
+  int* rend() const;
+};
+static_assert( std::is_invocable_v<RangeREndT, MemberBeginAndRBegin&>);
+static_assert( std::is_invocable_v<RangeCREndT, MemberBeginAndRBegin&>);
+static_assert( std::same_as<std::invoke_result_t<RangeREndT, MemberBeginAndRBegin&>, int*>);
+static_assert( std::same_as<std::invoke_result_t<RangeCREndT, MemberBeginAndRBegin&>, int*>);
+
+constexpr bool testBeginEnd() {
+  MemberBeginEnd a{};
+  const MemberBeginEnd aa{};
+  assert(base(std::ranges::rend(a).base()) == &a.b);
+  assert(base(std::ranges::crend(a).base()) == &a.cb);
+  assert(base(std::ranges::rend(aa).base()) == &aa.cb);
+  assert(base(std::ranges::crend(aa).base()) == &aa.cb);
+
+  FunctionBeginEnd b{};
+  const FunctionBeginEnd bb{};
+  assert(base(std::ranges::rend(b).base()) == &b.b);
+  assert(base(std::ranges::crend(b).base()) == &b.cb);
+  assert(base(std::ranges::rend(bb).base()) == &bb.cb);
+  assert(base(std::ranges::crend(bb).base()) == &bb.cb);
+
+  MemberBeginFunctionEnd c{};
+  const MemberBeginFunctionEnd cc{};
+  assert(base(std::ranges::rend(c).base()) == &c.b);
+  assert(base(std::ranges::crend(c).base()) == &c.cb);
+  assert(base(std::ranges::rend(cc).base()) == &cc.cb);
+  assert(base(std::ranges::crend(cc).base()) == &cc.cb);
+
+  FunctionBeginMemberEnd d{};
+  const FunctionBeginMemberEnd dd{};
+  assert(base(std::ranges::rend(d).base()) == &d.b);
+  assert(base(std::ranges::crend(d).base()) == &d.cb);
+  assert(base(std::ranges::rend(dd).base()) == &dd.cb);
+  assert(base(std::ranges::crend(dd).base()) == &dd.cb);
+
+  return true;
+}
+
+
+ASSERT_NOEXCEPT(std::ranges::rend(std::declval<int (&)[10]>()));
+ASSERT_NOEXCEPT(std::ranges::crend(std::declval<int (&)[10]>()));
+
+struct NoThrowMemberREnd {
+  ThrowingIterator<int> rbegin() const;
+  ThrowingIterator<int> rend() const noexcept; // auto(t.rend()) doesn't throw
+} ntmre;
+static_assert(noexcept(std::ranges::rend(ntmre)));
+static_assert(noexcept(std::ranges::crend(ntmre)));
+
+struct NoThrowADLREnd {
+  ThrowingIterator<int> rbegin() const;
+  friend ThrowingIterator<int> rend(NoThrowADLREnd&) noexcept;  // auto(rend(t)) doesn't throw
+  friend ThrowingIterator<int> rend(const NoThrowADLREnd&) noexcept;
+} ntare;
+static_assert(noexcept(std::ranges::rend(ntare)));
+static_assert(noexcept(std::ranges::crend(ntare)));
+
+struct NoThrowMemberREndReturnsRef {
+  ThrowingIterator<int> rbegin() const;
+  ThrowingIterator<int>& rend() const noexcept; // auto(t.rend()) may throw
+} ntmrerr;
+static_assert(!noexcept(std::ranges::rend(ntmrerr)));
+static_assert(!noexcept(std::ranges::crend(ntmrerr)));
+
+struct REndReturnsArrayRef {
+    auto rbegin() const noexcept -> int(&)[10];
+    auto rend() const noexcept -> int(&)[10];
+} rerar;
+static_assert(noexcept(std::ranges::rend(rerar)));
+static_assert(noexcept(std::ranges::crend(rerar)));
+
+struct NoThrowBeginThrowingEnd {
+  int* begin() const noexcept;
+  int* end() const;
+} ntbte;
+static_assert(noexcept(std::ranges::rend(ntbte)));
+static_assert(noexcept(std::ranges::crend(ntbte)));
+
+struct NoThrowEndThrowingBegin {
+  int* begin() const;
+  int* end() const noexcept;
+} ntetb;
+static_assert(!noexcept(std::ranges::rend(ntetb)));
+static_assert(!noexcept(std::ranges::crend(ntetb)));
+
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(!std::is_invocable_v<RangeREndT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeREndT, Holder<Incomplete>*&>);
+static_assert(!std::is_invocable_v<RangeCREndT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeCREndT, Holder<Incomplete>*&>);
+
+int main(int, char**) {
+  static_assert(testReturnTypes());
+
+  testArray();
+  static_assert(testArray());
+
+  testREndMember();
+  static_assert(testREndMember());
+
+  testREndFunction();
+  static_assert(testREndFunction());
+
+  testBeginEnd();
+  static_assert(testBeginEnd());
+
+  return 0;
+}

--- a/llvm/access/rend.pass.cpp
+++ b/llvm/access/rend.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/rend.pass.cpp
+++ b/llvm/access/rend.pass.cpp
@@ -11,542 +11,696 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::rend
-// std::ranges::crend
+// rxx::ranges::rend
+// rxx::ranges::crend
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
 
 #include <cassert>
 #include <utility>
-#include "test_macros.h"
-#include "test_iterators.h"
 
-using RangeREndT = decltype(std::ranges::rend);
-using RangeCREndT = decltype(std::ranges::crend);
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
+
+using RangeREndT = decltype(xranges::rend);
+using RangeCREndT = decltype(xranges::crend);
 
 static int globalBuff[8];
 
 static_assert(!std::is_invocable_v<RangeREndT, int (&&)[]>);
 static_assert(!std::is_invocable_v<RangeREndT, int (&)[]>);
 static_assert(!std::is_invocable_v<RangeREndT, int (&&)[10]>);
-static_assert( std::is_invocable_v<RangeREndT, int (&)[10]>);
+static_assert(std::is_invocable_v<RangeREndT, int (&)[10]>);
 static_assert(!std::is_invocable_v<RangeCREndT, int (&&)[]>);
 static_assert(!std::is_invocable_v<RangeCREndT, int (&)[]>);
 static_assert(!std::is_invocable_v<RangeCREndT, int (&&)[10]>);
-static_assert( std::is_invocable_v<RangeCREndT, int (&)[10]>);
+static_assert(std::is_invocable_v<RangeCREndT, int (&)[10]>);
 
 struct Incomplete;
-static_assert(!std::is_invocable_v<RangeREndT, Incomplete(&&)[]>);
-static_assert(!std::is_invocable_v<RangeREndT, Incomplete(&&)[42]>);
-static_assert(!std::is_invocable_v<RangeCREndT, Incomplete(&&)[]>);
-static_assert(!std::is_invocable_v<RangeCREndT, Incomplete(&&)[42]>);
+static_assert(!std::is_invocable_v<RangeREndT, Incomplete (&&)[]>);
+static_assert(!std::is_invocable_v<RangeREndT, Incomplete (&&)[42]>);
+static_assert(!std::is_invocable_v<RangeCREndT, Incomplete (&&)[]>);
+static_assert(!std::is_invocable_v<RangeCREndT, Incomplete (&&)[42]>);
 
 struct REndMember {
-  int x;
-  const int* rbegin() const;
-  constexpr const int* rend() const { return &x; }
+    int x;
+    int const* rbegin() const;
+    constexpr int const* rend() const { return &x; }
+
+    int const* begin() const { return &x; }
+    constexpr int const* end() const { return &x + 1; }
 };
 
 // Ensure that we can't call with rvalues with borrowing disabled.
-static_assert( std::is_invocable_v<RangeREndT, REndMember&>);
-static_assert(!std::is_invocable_v<RangeREndT, REndMember &&>);
-static_assert( std::is_invocable_v<RangeREndT, REndMember const&>);
+static_assert(std::is_invocable_v<RangeREndT, REndMember&>);
+static_assert(!std::is_invocable_v<RangeREndT, REndMember&&>);
+static_assert(std::is_invocable_v<RangeREndT, REndMember const&>);
 static_assert(!std::is_invocable_v<RangeREndT, REndMember const&&>);
-static_assert( std::is_invocable_v<RangeCREndT, REndMember &>);
-static_assert(!std::is_invocable_v<RangeCREndT, REndMember &&>);
-static_assert( std::is_invocable_v<RangeCREndT, REndMember const&>);
+static_assert(std::is_invocable_v<RangeCREndT, REndMember&>);
+static_assert(!std::is_invocable_v<RangeCREndT, REndMember&&>);
+static_assert(std::is_invocable_v<RangeCREndT, REndMember const&>);
 static_assert(!std::is_invocable_v<RangeCREndT, REndMember const&&>);
 
 constexpr bool testReturnTypes() {
-  {
-    int *x[2];
-    ASSERT_SAME_TYPE(decltype(std::ranges::rend(x)), std::reverse_iterator<int**>);
-    ASSERT_SAME_TYPE(decltype(std::ranges::crend(x)), std::reverse_iterator<int* const*>);
-  }
+    {
+        int* x[2];
+        ASSERT_SAME_TYPE(
+            decltype(xranges::rend(x)), std::reverse_iterator<int**>);
+        ASSERT_SAME_TYPE(
+            decltype(xranges::crend(x)), std::reverse_iterator<int* const*>);
+    }
 
-  {
-    int x[2][2];
-    ASSERT_SAME_TYPE(decltype(std::ranges::rend(x)), std::reverse_iterator<int(*)[2]>);
-    ASSERT_SAME_TYPE(decltype(std::ranges::crend(x)), std::reverse_iterator<const int(*)[2]>);
-  }
+    {
+        int x[2][2];
+        ASSERT_SAME_TYPE(
+            decltype(xranges::rend(x)), std::reverse_iterator<int(*)[2]>);
+        ASSERT_SAME_TYPE(decltype(xranges::crend(x)),
+            std::reverse_iterator<int const(*)[2]>);
+    }
 
-  {
-    struct Different {
-      char* rbegin();
-      sentinel_wrapper<char*>& rend();
-      short* rbegin() const;
-      sentinel_wrapper<short*>& rend() const;
-    } x;
-    ASSERT_SAME_TYPE(decltype(std::ranges::rend(x)), sentinel_wrapper<char*>);
-    ASSERT_SAME_TYPE(decltype(std::ranges::crend(x)), sentinel_wrapper<short*>);
-  }
+    {
+        struct Different {
+            char* rbegin();
+            sentinel_wrapper<char*>& rend();
+            short* rbegin() const;
+            sentinel_wrapper<short*>& rend() const;
 
-  return true;
+            char* begin();
+            sentinel_wrapper<char*>& end();
+            short* begin() const;
+            sentinel_wrapper<short*>& end() const;
+        } x;
+        ASSERT_SAME_TYPE(decltype(xranges::rend(x)), sentinel_wrapper<char*>);
+        ASSERT_SAME_TYPE(decltype(xranges::crend(x)), sentinel_wrapper<short*>);
+    }
+
+    return true;
 }
 
 constexpr bool testArray() {
-  int a[2];
-  assert(std::ranges::rend(a).base() == a);
-  assert(std::ranges::crend(a).base() == a);
+    int a[2];
+    assert(xranges::rend(a).base() == a);
+    assert(xranges::crend(a).base() == a);
 
-  int b[2][2];
-  assert(std::ranges::rend(b).base() == b);
-  assert(std::ranges::crend(b).base() == b);
+    int b[2][2];
+    assert(xranges::rend(b).base() == b);
+    assert(xranges::crend(b).base() == b);
 
-  REndMember c[2];
-  assert(std::ranges::rend(c).base() == c);
-  assert(std::ranges::crend(c).base() == c);
+    REndMember c[2];
+    assert(xranges::rend(c).base() == c);
+    assert(xranges::crend(c).base() == c);
 
-  return true;
+    return true;
 }
 
 struct REndMemberReturnsInt {
-  int rbegin() const;
-  int rend() const;
+    int rbegin() const;
+    int rend() const;
 };
 static_assert(!std::is_invocable_v<RangeREndT, REndMemberReturnsInt const&>);
 
 struct REndMemberReturnsVoidPtr {
-  const void *rbegin() const;
-  const void *rend() const;
+    void const* rbegin() const;
+    void const* rend() const;
 };
-static_assert(!std::is_invocable_v<RangeREndT, REndMemberReturnsVoidPtr const&>);
+static_assert(
+    !std::is_invocable_v<RangeREndT, REndMemberReturnsVoidPtr const&>);
 
 struct PtrConvertible {
-  operator int*() const;
+    operator int*() const;
 };
 struct PtrConvertibleREndMember {
-  PtrConvertible rbegin() const;
-  PtrConvertible rend() const;
+    PtrConvertible rbegin() const;
+    PtrConvertible rend() const;
 };
-static_assert(!std::is_invocable_v<RangeREndT, PtrConvertibleREndMember const&>);
+static_assert(
+    !std::is_invocable_v<RangeREndT, PtrConvertibleREndMember const&>);
 
 struct NoRBeginMember {
-  constexpr const int* rend();
+    constexpr int const* rend();
 };
 static_assert(!std::is_invocable_v<RangeREndT, NoRBeginMember const&>);
 
 struct NonConstREndMember {
-  int x;
-  constexpr int* rbegin() { return nullptr; }
-  constexpr int* rend() { return &x; }
+    int x;
+    constexpr int* rbegin() { return nullptr; }
+    constexpr int* rend() { return &x; }
 };
-static_assert( std::is_invocable_v<RangeREndT,  NonConstREndMember &>);
-static_assert(!std::is_invocable_v<RangeREndT,  NonConstREndMember const&>);
-static_assert(!std::is_invocable_v<RangeCREndT, NonConstREndMember &>);
+static_assert(std::is_invocable_v<RangeREndT, NonConstREndMember&>);
+static_assert(!std::is_invocable_v<RangeREndT, NonConstREndMember const&>);
+static_assert(!std::is_invocable_v<RangeCREndT, NonConstREndMember&>);
 static_assert(!std::is_invocable_v<RangeCREndT, NonConstREndMember const&>);
 
 struct EnabledBorrowingREndMember {
-  constexpr int* rbegin() const { return nullptr; }
-  constexpr int* rend() const { return &globalBuff[0]; }
+    constexpr int* rbegin() const { return nullptr; }
+    constexpr int* rend() const { return &globalBuff[0]; }
+
+    constexpr int* begin() const { return &globalBuff[0]; }
+    constexpr int* end() const { return nullptr; }
 };
 
 template <>
-inline constexpr bool std::ranges::enable_borrowed_range<EnabledBorrowingREndMember> = true;
+inline constexpr bool
+    std::ranges::enable_borrowed_range<EnabledBorrowingREndMember> = true;
 
 struct REndMemberFunction {
-  int x;
-  constexpr const int* rbegin() const { return nullptr; }
-  constexpr const int* rend() const { return &x; }
-  friend constexpr int* rend(REndMemberFunction const&);
+    int x;
+    constexpr int const* rbegin() const { return nullptr; }
+    constexpr int const* rend() const { return &x; }
+    constexpr int const* begin() const { return &x; }
+    constexpr int const* end() const { return nullptr; }
+    friend constexpr int* rend(REndMemberFunction const&);
 };
 
-struct Empty { };
+struct Empty {};
 struct EmptyEndMember {
-  Empty rbegin() const;
-  Empty rend() const;
+    Empty rbegin() const;
+    Empty rend() const;
 };
 static_assert(!std::is_invocable_v<RangeREndT, EmptyEndMember const&>);
 
 struct EmptyPtrREndMember {
-  Empty x;
-  constexpr const Empty* rbegin() const { return nullptr; }
-  constexpr const Empty* rend() const { return &x; }
+    Empty x;
+    constexpr Empty const* rbegin() const { return nullptr; }
+    constexpr Empty const* rend() const { return &x; }
+    constexpr Empty const* begin() const { return &x; }
+    constexpr Empty const* end() const { return nullptr; }
 };
 
 constexpr bool testREndMember() {
-  REndMember a;
-  assert(std::ranges::rend(a) == &a.x);
-  assert(std::ranges::crend(a) == &a.x);
+    REndMember a;
+    assert(xranges::rend(a) == &a.x);
+    assert(xranges::crend(a) == &a.x);
 
-  NonConstREndMember b;
-  assert(std::ranges::rend(b) == &b.x);
-  static_assert(!std::is_invocable_v<RangeCREndT, decltype((b))>);
+    NonConstREndMember b;
+    assert(xranges::rend(b) == &b.x);
+    static_assert(!std::is_invocable_v<RangeCREndT, decltype((b))>);
 
-  EnabledBorrowingREndMember c;
-  assert(std::ranges::rend(std::move(c)) == &globalBuff[0]);
-  assert(std::ranges::crend(std::move(c)) == &globalBuff[0]);
+    EnabledBorrowingREndMember c;
+    assert(xranges::rend(std::move(c)) == &globalBuff[0]);
+    assert(xranges::crend(std::move(c)) == &globalBuff[0]);
 
-  REndMemberFunction d;
-  assert(std::ranges::rend(d) == &d.x);
-  assert(std::ranges::crend(d) == &d.x);
+    REndMemberFunction d;
+    assert(xranges::rend(d) == &d.x);
+    assert(xranges::crend(d) == &d.x);
 
-  EmptyPtrREndMember e;
-  assert(std::ranges::rend(e) == &e.x);
-  assert(std::ranges::crend(e) == &e.x);
+    EmptyPtrREndMember e;
+    assert(xranges::rend(e) == &e.x);
+    assert(xranges::crend(e) == &e.x);
 
-  return true;
+    return true;
 }
 
 struct REndFunction {
-  int x;
-  friend constexpr const int* rbegin(REndFunction const&) { return nullptr; }
-  friend constexpr const int* rend(REndFunction const& bf) { return &bf.x; }
+    int x;
+    friend constexpr int const* rbegin(REndFunction const&) { return nullptr; }
+    friend constexpr int const* rend(REndFunction const& bf) { return &bf.x; }
+
+    friend constexpr int const* begin(REndFunction const& bf) { return &bf.x; }
+    friend constexpr int const* end(REndFunction const&) { return nullptr; }
 };
 
-static_assert( std::is_invocable_v<RangeREndT, REndFunction const&>);
-static_assert(!std::is_invocable_v<RangeREndT, REndFunction &&>);
+static_assert(std::is_invocable_v<RangeREndT, REndFunction const&>);
+static_assert(!std::is_invocable_v<RangeREndT, REndFunction&&>);
 
-static_assert( std::is_invocable_v<RangeREndT,  REndFunction const&>);
-static_assert(!std::is_invocable_v<RangeREndT,  REndFunction &&>);
-static_assert(std::is_invocable_v<RangeREndT, REndFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-static_assert( std::is_invocable_v<RangeCREndT, REndFunction const&>);
-static_assert( std::is_invocable_v<RangeCREndT, REndFunction &>);
+static_assert(std::is_invocable_v<RangeREndT, REndFunction const&>);
+static_assert(!std::is_invocable_v<RangeREndT, REndFunction&&>);
+static_assert(std::is_invocable_v<RangeREndT,
+    REndFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+static_assert(std::is_invocable_v<RangeCREndT, REndFunction const&>);
+static_assert(std::is_invocable_v<RangeCREndT, REndFunction&>);
 
 struct REndFunctionReturnsInt {
-  friend constexpr int rbegin(REndFunctionReturnsInt const&);
-  friend constexpr int rend(REndFunctionReturnsInt const&);
+    friend constexpr int rbegin(REndFunctionReturnsInt const&);
+    friend constexpr int rend(REndFunctionReturnsInt const&);
+    friend constexpr int begin(REndFunctionReturnsInt const&);
+    friend constexpr int end(REndFunctionReturnsInt const&);
 };
 static_assert(!std::is_invocable_v<RangeREndT, REndFunctionReturnsInt const&>);
 
 struct REndFunctionReturnsVoidPtr {
-  friend constexpr void* rbegin(REndFunctionReturnsVoidPtr const&);
-  friend constexpr void* rend(REndFunctionReturnsVoidPtr const&);
+    friend constexpr void* rbegin(REndFunctionReturnsVoidPtr const&);
+    friend constexpr void* rend(REndFunctionReturnsVoidPtr const&);
+    friend constexpr void* begin(REndFunctionReturnsVoidPtr const&);
+    friend constexpr void* end(REndFunctionReturnsVoidPtr const&);
 };
-static_assert(!std::is_invocable_v<RangeREndT, REndFunctionReturnsVoidPtr const&>);
+static_assert(
+    !std::is_invocable_v<RangeREndT, REndFunctionReturnsVoidPtr const&>);
 
 struct REndFunctionReturnsEmpty {
-  friend constexpr Empty rbegin(REndFunctionReturnsEmpty const&);
-  friend constexpr Empty rend(REndFunctionReturnsEmpty const&);
+    friend constexpr Empty rbegin(REndFunctionReturnsEmpty const&);
+    friend constexpr Empty rend(REndFunctionReturnsEmpty const&);
+    friend constexpr Empty begin(REndFunctionReturnsEmpty const&);
+    friend constexpr Empty end(REndFunctionReturnsEmpty const&);
 };
-static_assert(!std::is_invocable_v<RangeREndT, REndFunctionReturnsEmpty const&>);
+static_assert(
+    !std::is_invocable_v<RangeREndT, REndFunctionReturnsEmpty const&>);
 
 struct REndFunctionReturnsPtrConvertible {
-  friend constexpr PtrConvertible rbegin(REndFunctionReturnsPtrConvertible const&);
-  friend constexpr PtrConvertible rend(REndFunctionReturnsPtrConvertible const&);
+    friend constexpr PtrConvertible rbegin(
+        REndFunctionReturnsPtrConvertible const&);
+    friend constexpr PtrConvertible rend(
+        REndFunctionReturnsPtrConvertible const&);
+    friend constexpr PtrConvertible begin(
+        REndFunctionReturnsPtrConvertible const&);
+    friend constexpr PtrConvertible end(
+        REndFunctionReturnsPtrConvertible const&);
 };
-static_assert(!std::is_invocable_v<RangeREndT, REndFunctionReturnsPtrConvertible const&>);
+static_assert(
+    !std::is_invocable_v<RangeREndT, REndFunctionReturnsPtrConvertible const&>);
 
 struct NoRBeginFunction {
-  friend constexpr const int* rend(NoRBeginFunction const&);
+    friend constexpr int const* rend(NoRBeginFunction const&);
 };
 static_assert(!std::is_invocable_v<RangeREndT, NoRBeginFunction const&>);
 
 struct REndFunctionByValue {
-  friend constexpr int* rbegin(REndFunctionByValue) { return nullptr; }
-  friend constexpr int* rend(REndFunctionByValue) { return &globalBuff[1]; }
+    friend constexpr int* rbegin(REndFunctionByValue) { return nullptr; }
+    friend constexpr int* rend(REndFunctionByValue) { return &globalBuff[1]; }
+
+    friend constexpr int* begin(REndFunctionByValue) { return &globalBuff[1]; }
+    friend constexpr int* end(REndFunctionByValue) { return nullptr; }
 };
 static_assert(!std::is_invocable_v<RangeCREndT, REndFunctionByValue>);
 
 struct REndFunctionEnabledBorrowing {
-  friend constexpr int* rbegin(REndFunctionEnabledBorrowing) { return nullptr; }
-  friend constexpr int* rend(REndFunctionEnabledBorrowing) { return &globalBuff[2]; }
+    friend constexpr int* rbegin(REndFunctionEnabledBorrowing) {
+        return nullptr;
+    }
+    friend constexpr int* rend(REndFunctionEnabledBorrowing) {
+        return &globalBuff[2];
+    }
+
+    friend constexpr int* begin(REndFunctionEnabledBorrowing) {
+        return &globalBuff[2];
+    }
+    friend constexpr int* end(REndFunctionEnabledBorrowing) { return nullptr; }
 };
-template<>
-inline constexpr bool std::ranges::enable_borrowed_range<REndFunctionEnabledBorrowing> = true;
+template <>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<REndFunctionEnabledBorrowing> = true;
 
 struct REndFunctionReturnsEmptyPtr {
-  Empty x;
-  friend constexpr const Empty* rbegin(REndFunctionReturnsEmptyPtr const&) { return nullptr; }
-  friend constexpr const Empty* rend(REndFunctionReturnsEmptyPtr const& bf) { return &bf.x; }
+    Empty x;
+    friend constexpr Empty const* rbegin(REndFunctionReturnsEmptyPtr const&) {
+        return nullptr;
+    }
+    friend constexpr Empty const* rend(REndFunctionReturnsEmptyPtr const& bf) {
+        return &bf.x;
+    }
+
+    friend constexpr Empty const* begin(REndFunctionReturnsEmptyPtr const& bf) {
+        return &bf.x;
+    }
+    friend constexpr Empty const* end(REndFunctionReturnsEmptyPtr const&) {
+        return nullptr;
+    }
 };
 
 struct REndFunctionWithDataMember {
-  int x;
-  int rend;
-  friend constexpr const int* rbegin(REndFunctionWithDataMember const&) { return nullptr; }
-  friend constexpr const int* rend(REndFunctionWithDataMember const& bf) { return &bf.x; }
+    int x;
+    int rend;
+    friend constexpr int const* rbegin(REndFunctionWithDataMember const&) {
+        return nullptr;
+    }
+    friend constexpr int const* rend(REndFunctionWithDataMember const& bf) {
+        return &bf.x;
+    }
+
+    friend constexpr int const* begin(REndFunctionWithDataMember const& bf) {
+        return &bf.x;
+    }
+    friend constexpr int const* end(REndFunctionWithDataMember const&) {
+        return nullptr;
+    }
 };
 
 struct REndFunctionWithPrivateEndMember : private REndMember {
-  int y;
-  friend constexpr const int* rbegin(REndFunctionWithPrivateEndMember const&) { return nullptr; }
-  friend constexpr const int* rend(REndFunctionWithPrivateEndMember const& bf) { return &bf.y; }
+    int y;
+    friend constexpr int const* rbegin(
+        REndFunctionWithPrivateEndMember const&) {
+        return nullptr;
+    }
+    friend constexpr int const* rend(
+        REndFunctionWithPrivateEndMember const& bf) {
+        return &bf.y;
+    }
+
+    friend constexpr int const* begin(
+        REndFunctionWithPrivateEndMember const& bf) {
+        return &bf.y;
+    }
+    friend constexpr int const* end(REndFunctionWithPrivateEndMember const&) {
+        return nullptr;
+    }
 };
 
 struct RBeginMemberEndFunction {
-  int x;
-  constexpr const int* rbegin() const { return nullptr; }
-  friend constexpr const int* rend(RBeginMemberEndFunction const& bf) { return &bf.x; }
+    int x;
+    constexpr int const* rbegin() const { return nullptr; }
+    friend constexpr int const* rend(RBeginMemberEndFunction const& bf) {
+        return &bf.x;
+    }
+
+    constexpr int const* begin() const { return &x; }
+    constexpr int const* end() const { return nullptr; }
 };
 
 constexpr bool testREndFunction() {
-  const REndFunction a{};
-  assert(std::ranges::rend(a) == &a.x);
-  assert(std::ranges::crend(a) == &a.x);
-  REndFunction aa{};
-  assert(std::ranges::rend(aa) == &aa.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::crend(aa) == &aa.x);
+    REndFunction const a{};
+    assert(xranges::rend(a) == &a.x);
+    assert(xranges::crend(a) == &a.x);
+    REndFunction aa{};
+    assert(xranges::rend(aa) ==
+        &aa.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::crend(aa) == &aa.x);
 
-  REndFunctionByValue b;
-  assert(std::ranges::rend(b) == &globalBuff[1]);
-  assert(std::ranges::crend(b) == &globalBuff[1]);
+    REndFunctionByValue b;
+    assert(xranges::rend(b) == &globalBuff[1]);
+    assert(xranges::crend(b) == &globalBuff[1]);
 
-  REndFunctionEnabledBorrowing c;
-  assert(std::ranges::rend(std::move(c)) == &globalBuff[2]);
-  assert(std::ranges::crend(std::move(c)) == &globalBuff[2]);
+    REndFunctionEnabledBorrowing c;
+    assert(xranges::rend(std::move(c)) == &globalBuff[2]);
+    assert(xranges::crend(std::move(c)) == &globalBuff[2]);
 
-  const REndFunctionReturnsEmptyPtr d{};
-  assert(std::ranges::rend(d) == &d.x);
-  assert(std::ranges::crend(d) == &d.x);
-  REndFunctionReturnsEmptyPtr dd{};
-  assert(std::ranges::rend(dd) == &dd.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::crend(dd) == &dd.x);
+    REndFunctionReturnsEmptyPtr const d{};
+    assert(xranges::rend(d) == &d.x);
+    assert(xranges::crend(d) == &d.x);
+    REndFunctionReturnsEmptyPtr dd{};
+    assert(xranges::rend(dd) ==
+        &dd.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::crend(dd) == &dd.x);
 
-  const REndFunctionWithDataMember e{};
-  assert(std::ranges::rend(e) == &e.x);
-  assert(std::ranges::crend(e) == &e.x);
-  REndFunctionWithDataMember ee{};
-  assert(std::ranges::rend(ee) == &ee.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::crend(ee) == &ee.x);
+    REndFunctionWithDataMember const e{};
+    assert(xranges::rend(e) == &e.x);
+    assert(xranges::crend(e) == &e.x);
+    REndFunctionWithDataMember ee{};
+    assert(xranges::rend(ee) ==
+        &ee.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::crend(ee) == &ee.x);
 
-  const REndFunctionWithPrivateEndMember f{};
-  assert(std::ranges::rend(f) == &f.y);
-  assert(std::ranges::crend(f) == &f.y);
-  REndFunctionWithPrivateEndMember ff{};
-  assert(std::ranges::rend(ff) == &ff.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::crend(ff) == &ff.y);
+    REndFunctionWithPrivateEndMember const f{};
+    assert(xranges::rend(f) == &f.y);
+    assert(xranges::crend(f) == &f.y);
+    REndFunctionWithPrivateEndMember ff{};
+    assert(xranges::rend(ff) ==
+        &ff.y); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::crend(ff) == &ff.y);
 
-  const RBeginMemberEndFunction g{};
-  assert(std::ranges::rend(g) == &g.x);
-  assert(std::ranges::crend(g) == &g.x);
-  RBeginMemberEndFunction gg{};
-  assert(std::ranges::rend(gg) == &gg.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-  assert(std::ranges::crend(gg) == &gg.x);
+    RBeginMemberEndFunction const g{};
+    assert(xranges::rend(g) == &g.x);
+    assert(xranges::crend(g) == &g.x);
+    RBeginMemberEndFunction gg{};
+    assert(xranges::rend(gg) ==
+        &gg.x); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+    assert(xranges::crend(gg) == &gg.x);
 
-  return true;
+    return true;
 }
 
-
 struct MemberBeginEnd {
-  int b, e;
-  char cb, ce;
-  constexpr bidirectional_iterator<int*> begin() { return bidirectional_iterator<int*>(&b); }
-  constexpr bidirectional_iterator<int*> end() { return bidirectional_iterator<int*>(&e); }
-  constexpr bidirectional_iterator<const char*> begin() const { return bidirectional_iterator<const char*>(&cb); }
-  constexpr bidirectional_iterator<const char*> end() const { return bidirectional_iterator<const char*>(&ce); }
+    int b, e;
+    char cb, ce;
+    constexpr bidirectional_iterator<int*> begin() {
+        return bidirectional_iterator<int*>(&b);
+    }
+    constexpr bidirectional_iterator<int*> end() {
+        return bidirectional_iterator<int*>(&e);
+    }
+    constexpr bidirectional_iterator<char const*> begin() const {
+        return bidirectional_iterator<char const*>(&cb);
+    }
+    constexpr bidirectional_iterator<char const*> end() const {
+        return bidirectional_iterator<char const*>(&ce);
+    }
 };
-static_assert( std::is_invocable_v<RangeREndT, MemberBeginEnd&>);
-static_assert( std::is_invocable_v<RangeREndT, MemberBeginEnd const&>);
-static_assert( std::is_invocable_v<RangeCREndT, MemberBeginEnd const&>);
+static_assert(std::is_invocable_v<RangeREndT, MemberBeginEnd&>);
+static_assert(std::is_invocable_v<RangeREndT, MemberBeginEnd const&>);
+static_assert(std::is_invocable_v<RangeCREndT, MemberBeginEnd const&>);
 
 struct FunctionBeginEnd {
-  int b, e;
-  char cb, ce;
-  friend constexpr bidirectional_iterator<int*> begin(FunctionBeginEnd& v) {
-    return bidirectional_iterator<int*>(&v.b);
-  }
-  friend constexpr bidirectional_iterator<int*> end(FunctionBeginEnd& v) { return bidirectional_iterator<int*>(&v.e); }
-  friend constexpr bidirectional_iterator<const char*> begin(const FunctionBeginEnd& v) {
-    return bidirectional_iterator<const char*>(&v.cb);
-  }
-  friend constexpr bidirectional_iterator<const char*> end(const FunctionBeginEnd& v) {
-    return bidirectional_iterator<const char*>(&v.ce);
-  }
+    int b, e;
+    char cb, ce;
+    friend constexpr bidirectional_iterator<int*> begin(FunctionBeginEnd& v) {
+        return bidirectional_iterator<int*>(&v.b);
+    }
+    friend constexpr bidirectional_iterator<int*> end(FunctionBeginEnd& v) {
+        return bidirectional_iterator<int*>(&v.e);
+    }
+    friend constexpr bidirectional_iterator<char const*> begin(
+        FunctionBeginEnd const& v) {
+        return bidirectional_iterator<char const*>(&v.cb);
+    }
+    friend constexpr bidirectional_iterator<char const*> end(
+        FunctionBeginEnd const& v) {
+        return bidirectional_iterator<char const*>(&v.ce);
+    }
 };
-static_assert( std::is_invocable_v<RangeREndT, FunctionBeginEnd&>);
-static_assert( std::is_invocable_v<RangeREndT, FunctionBeginEnd const&>);
-static_assert( std::is_invocable_v<RangeCREndT, FunctionBeginEnd const&>);
+static_assert(std::is_invocable_v<RangeREndT, FunctionBeginEnd&>);
+static_assert(std::is_invocable_v<RangeREndT, FunctionBeginEnd const&>);
+static_assert(std::is_invocable_v<RangeCREndT, FunctionBeginEnd const&>);
 
 struct MemberBeginFunctionEnd {
-  int b, e;
-  char cb, ce;
-  constexpr bidirectional_iterator<int*> begin() { return bidirectional_iterator<int*>(&b); }
-  friend constexpr bidirectional_iterator<int*> end(MemberBeginFunctionEnd& v) {
-    return bidirectional_iterator<int*>(&v.e);
-  }
-  constexpr bidirectional_iterator<const char*> begin() const { return bidirectional_iterator<const char*>(&cb); }
-  friend constexpr bidirectional_iterator<const char*> end(const MemberBeginFunctionEnd& v) {
-    return bidirectional_iterator<const char*>(&v.ce);
-  }
+    int b, e;
+    char cb, ce;
+    constexpr bidirectional_iterator<int*> begin() {
+        return bidirectional_iterator<int*>(&b);
+    }
+    friend constexpr bidirectional_iterator<int*> end(
+        MemberBeginFunctionEnd& v) {
+        return bidirectional_iterator<int*>(&v.e);
+    }
+    constexpr bidirectional_iterator<char const*> begin() const {
+        return bidirectional_iterator<char const*>(&cb);
+    }
+    friend constexpr bidirectional_iterator<char const*> end(
+        MemberBeginFunctionEnd const& v) {
+        return bidirectional_iterator<char const*>(&v.ce);
+    }
 };
-static_assert( std::is_invocable_v<RangeREndT, MemberBeginFunctionEnd&>);
-static_assert( std::is_invocable_v<RangeREndT, MemberBeginFunctionEnd const&>);
-static_assert( std::is_invocable_v<RangeCREndT, MemberBeginFunctionEnd const&>);
+static_assert(std::is_invocable_v<RangeREndT, MemberBeginFunctionEnd&>);
+static_assert(std::is_invocable_v<RangeREndT, MemberBeginFunctionEnd const&>);
+static_assert(std::is_invocable_v<RangeCREndT, MemberBeginFunctionEnd const&>);
 
 struct FunctionBeginMemberEnd {
-  int b, e;
-  char cb, ce;
-  friend constexpr bidirectional_iterator<int*> begin(FunctionBeginMemberEnd& v) {
-    return bidirectional_iterator<int*>(&v.b);
-  }
-  constexpr bidirectional_iterator<int*> end() { return bidirectional_iterator<int*>(&e); }
-  friend constexpr bidirectional_iterator<const char*> begin(const FunctionBeginMemberEnd& v) {
-    return bidirectional_iterator<const char*>(&v.cb);
-  }
-  constexpr bidirectional_iterator<const char*> end() const { return bidirectional_iterator<const char*>(&ce); }
+    int b, e;
+    char cb, ce;
+    friend constexpr bidirectional_iterator<int*> begin(
+        FunctionBeginMemberEnd& v) {
+        return bidirectional_iterator<int*>(&v.b);
+    }
+    constexpr bidirectional_iterator<int*> end() {
+        return bidirectional_iterator<int*>(&e);
+    }
+    friend constexpr bidirectional_iterator<char const*> begin(
+        FunctionBeginMemberEnd const& v) {
+        return bidirectional_iterator<char const*>(&v.cb);
+    }
+    constexpr bidirectional_iterator<char const*> end() const {
+        return bidirectional_iterator<char const*>(&ce);
+    }
 };
-static_assert( std::is_invocable_v<RangeREndT, FunctionBeginMemberEnd&>);
-static_assert( std::is_invocable_v<RangeREndT, FunctionBeginMemberEnd const&>);
-static_assert( std::is_invocable_v<RangeCREndT, FunctionBeginMemberEnd const&>);
+static_assert(std::is_invocable_v<RangeREndT, FunctionBeginMemberEnd&>);
+static_assert(std::is_invocable_v<RangeREndT, FunctionBeginMemberEnd const&>);
+static_assert(std::is_invocable_v<RangeCREndT, FunctionBeginMemberEnd const&>);
 
 struct MemberBeginEndDifferentTypes {
-  bidirectional_iterator<int*> begin();
-  bidirectional_iterator<const int*> end();
+    bidirectional_iterator<int*> begin();
+    bidirectional_iterator<int const*> end();
 };
 static_assert(!std::is_invocable_v<RangeREndT, MemberBeginEndDifferentTypes&>);
 static_assert(!std::is_invocable_v<RangeCREndT, MemberBeginEndDifferentTypes&>);
 
 struct FunctionBeginEndDifferentTypes {
-  friend bidirectional_iterator<int*> begin(FunctionBeginEndDifferentTypes&);
-  friend bidirectional_iterator<const int*> end(FunctionBeginEndDifferentTypes&);
+    friend bidirectional_iterator<int*> begin(FunctionBeginEndDifferentTypes&);
+    friend bidirectional_iterator<int const*> end(
+        FunctionBeginEndDifferentTypes&);
 };
-static_assert(!std::is_invocable_v<RangeREndT, FunctionBeginEndDifferentTypes&>);
-static_assert(!std::is_invocable_v<RangeCREndT, FunctionBeginEndDifferentTypes&>);
+static_assert(
+    !std::is_invocable_v<RangeREndT, FunctionBeginEndDifferentTypes&>);
+static_assert(
+    !std::is_invocable_v<RangeCREndT, FunctionBeginEndDifferentTypes&>);
 
 struct MemberBeginEndForwardIterators {
-  forward_iterator<int*> begin();
-  forward_iterator<int*> end();
+    forward_iterator<int*> begin();
+    forward_iterator<int*> end();
 };
-static_assert(!std::is_invocable_v<RangeREndT, MemberBeginEndForwardIterators&>);
-static_assert(!std::is_invocable_v<RangeCREndT, MemberBeginEndForwardIterators&>);
+static_assert(
+    !std::is_invocable_v<RangeREndT, MemberBeginEndForwardIterators&>);
+static_assert(
+    !std::is_invocable_v<RangeCREndT, MemberBeginEndForwardIterators&>);
 
 struct FunctionBeginEndForwardIterators {
-  friend forward_iterator<int*> begin(FunctionBeginEndForwardIterators&);
-  friend forward_iterator<int*> end(FunctionBeginEndForwardIterators&);
+    friend forward_iterator<int*> begin(FunctionBeginEndForwardIterators&);
+    friend forward_iterator<int*> end(FunctionBeginEndForwardIterators&);
 };
-static_assert(!std::is_invocable_v<RangeREndT, FunctionBeginEndForwardIterators&>);
-static_assert(!std::is_invocable_v<RangeCREndT, FunctionBeginEndForwardIterators&>);
+static_assert(
+    !std::is_invocable_v<RangeREndT, FunctionBeginEndForwardIterators&>);
+static_assert(
+    !std::is_invocable_v<RangeCREndT, FunctionBeginEndForwardIterators&>);
 
 struct MemberBeginOnly {
-  bidirectional_iterator<int*> begin() const;
+    bidirectional_iterator<int*> begin() const;
 };
 static_assert(!std::is_invocable_v<RangeREndT, MemberBeginOnly&>);
 static_assert(!std::is_invocable_v<RangeCREndT, MemberBeginOnly&>);
 
 struct FunctionBeginOnly {
-  friend bidirectional_iterator<int*> begin(FunctionBeginOnly&);
+    friend bidirectional_iterator<int*> begin(FunctionBeginOnly&);
 };
 static_assert(!std::is_invocable_v<RangeREndT, FunctionBeginOnly&>);
 static_assert(!std::is_invocable_v<RangeCREndT, FunctionBeginOnly&>);
 
 struct MemberEndOnly {
-  bidirectional_iterator<int*> end() const;
+    bidirectional_iterator<int*> end() const;
 };
 static_assert(!std::is_invocable_v<RangeREndT, MemberEndOnly&>);
 static_assert(!std::is_invocable_v<RangeCREndT, MemberEndOnly&>);
 
 struct FunctionEndOnly {
-  friend bidirectional_iterator<int*> end(FunctionEndOnly&);
+    friend bidirectional_iterator<int*> end(FunctionEndOnly&);
 };
 static_assert(!std::is_invocable_v<RangeREndT, FunctionEndOnly&>);
 static_assert(!std::is_invocable_v<RangeCREndT, FunctionEndOnly&>);
 
 // Make sure there is no clash between the following cases:
-// - the case that handles classes defining member `rbegin` and `rend` functions;
-// - the case that handles classes defining `begin` and `end` functions returning reversible iterators.
+// - the case that handles classes defining member `rbegin` and `rend`
+// functions;
+// - the case that handles classes defining `begin` and `end` functions
+// returning reversible iterators.
 struct MemberBeginAndRBegin {
-  int* begin() const;
-  int* end() const;
-  int* rbegin() const;
-  int* rend() const;
+    int* begin() const;
+    int* end() const;
+    int* rbegin() const;
+    int* rend() const;
 };
-static_assert( std::is_invocable_v<RangeREndT, MemberBeginAndRBegin&>);
-static_assert( std::is_invocable_v<RangeCREndT, MemberBeginAndRBegin&>);
-static_assert( std::same_as<std::invoke_result_t<RangeREndT, MemberBeginAndRBegin&>, int*>);
-static_assert( std::same_as<std::invoke_result_t<RangeCREndT, MemberBeginAndRBegin&>, int*>);
+static_assert(std::is_invocable_v<RangeREndT, MemberBeginAndRBegin&>);
+static_assert(std::is_invocable_v<RangeCREndT, MemberBeginAndRBegin&>);
+static_assert(
+    std::same_as<std::invoke_result_t<RangeREndT, MemberBeginAndRBegin&>,
+        int*>);
+static_assert(
+    std::same_as<std::invoke_result_t<RangeCREndT, MemberBeginAndRBegin&>,
+        int const*>);
 
 constexpr bool testBeginEnd() {
-  MemberBeginEnd a{};
-  const MemberBeginEnd aa{};
-  assert(base(std::ranges::rend(a).base()) == &a.b);
-  assert(base(std::ranges::crend(a).base()) == &a.cb);
-  assert(base(std::ranges::rend(aa).base()) == &aa.cb);
-  assert(base(std::ranges::crend(aa).base()) == &aa.cb);
+    MemberBeginEnd a{};
+    MemberBeginEnd const aa{};
+    assert(base(xranges::rend(a).base()) == &a.b);
+    assert(base(xranges::crend(a).base()) == &a.cb);
+    assert(base(xranges::rend(aa).base()) == &aa.cb);
+    assert(base(xranges::crend(aa).base()) == &aa.cb);
 
-  FunctionBeginEnd b{};
-  const FunctionBeginEnd bb{};
-  assert(base(std::ranges::rend(b).base()) == &b.b);
-  assert(base(std::ranges::crend(b).base()) == &b.cb);
-  assert(base(std::ranges::rend(bb).base()) == &bb.cb);
-  assert(base(std::ranges::crend(bb).base()) == &bb.cb);
+    FunctionBeginEnd b{};
+    FunctionBeginEnd const bb{};
+    assert(base(xranges::rend(b).base()) == &b.b);
+    assert(base(xranges::crend(b).base()) == &b.cb);
+    assert(base(xranges::rend(bb).base()) == &bb.cb);
+    assert(base(xranges::crend(bb).base()) == &bb.cb);
 
-  MemberBeginFunctionEnd c{};
-  const MemberBeginFunctionEnd cc{};
-  assert(base(std::ranges::rend(c).base()) == &c.b);
-  assert(base(std::ranges::crend(c).base()) == &c.cb);
-  assert(base(std::ranges::rend(cc).base()) == &cc.cb);
-  assert(base(std::ranges::crend(cc).base()) == &cc.cb);
+    MemberBeginFunctionEnd c{};
+    MemberBeginFunctionEnd const cc{};
+    assert(base(xranges::rend(c).base()) == &c.b);
+    assert(base(xranges::crend(c).base()) == &c.cb);
+    assert(base(xranges::rend(cc).base()) == &cc.cb);
+    assert(base(xranges::crend(cc).base()) == &cc.cb);
 
-  FunctionBeginMemberEnd d{};
-  const FunctionBeginMemberEnd dd{};
-  assert(base(std::ranges::rend(d).base()) == &d.b);
-  assert(base(std::ranges::crend(d).base()) == &d.cb);
-  assert(base(std::ranges::rend(dd).base()) == &dd.cb);
-  assert(base(std::ranges::crend(dd).base()) == &dd.cb);
+    FunctionBeginMemberEnd d{};
+    FunctionBeginMemberEnd const dd{};
+    assert(base(xranges::rend(d).base()) == &d.b);
+    assert(base(xranges::crend(d).base()) == &d.cb);
+    assert(base(xranges::rend(dd).base()) == &dd.cb);
+    assert(base(xranges::crend(dd).base()) == &dd.cb);
 
-  return true;
+    return true;
 }
 
-
-ASSERT_NOEXCEPT(std::ranges::rend(std::declval<int (&)[10]>()));
-ASSERT_NOEXCEPT(std::ranges::crend(std::declval<int (&)[10]>()));
+// make_reverse_iterator is not noexcept
+ASSERT_NOT_NOEXCEPT(xranges::rend(std::declval<int (&)[10]>()));
+// make_reverse_iterator is not noexcept
+ASSERT_NOT_NOEXCEPT(xranges::crend(std::declval<int (&)[10]>()));
 
 struct NoThrowMemberREnd {
-  ThrowingIterator<int> rbegin() const;
-  ThrowingIterator<int> rend() const noexcept; // auto(t.rend()) doesn't throw
+    ThrowingIterator<int> rbegin() const;
+    ThrowingIterator<int> rend() const noexcept; // auto(t.rend()) doesn't throw
+
+    int const* begin() const;
+    int const* end() const;
 } ntmre;
-static_assert(noexcept(std::ranges::rend(ntmre)));
-static_assert(noexcept(std::ranges::crend(ntmre)));
+static_assert(noexcept(xranges::rend(ntmre)));
+static_assert(noexcept(xranges::crend(ntmre)));
 
 struct NoThrowADLREnd {
-  ThrowingIterator<int> rbegin() const;
-  friend ThrowingIterator<int> rend(NoThrowADLREnd&) noexcept;  // auto(rend(t)) doesn't throw
-  friend ThrowingIterator<int> rend(const NoThrowADLREnd&) noexcept;
+    ThrowingIterator<int> rbegin() const;
+    friend ThrowingIterator<int> rend(
+        NoThrowADLREnd&) noexcept; // auto(rend(t)) doesn't throw
+    friend ThrowingIterator<int> rend(NoThrowADLREnd const&) noexcept;
+    int const* begin() const;
+    int const* end() const;
 } ntare;
-static_assert(noexcept(std::ranges::rend(ntare)));
-static_assert(noexcept(std::ranges::crend(ntare)));
+static_assert(noexcept(xranges::rend(ntare)));
+static_assert(noexcept(xranges::crend(ntare)));
 
 struct NoThrowMemberREndReturnsRef {
-  ThrowingIterator<int> rbegin() const;
-  ThrowingIterator<int>& rend() const noexcept; // auto(t.rend()) may throw
+    ThrowingIterator<int> rbegin() const;
+    ThrowingIterator<int>& rend() const noexcept; // auto(t.rend()) may throw
+    int const* begin() const;
+    int const* end() const;
 } ntmrerr;
-static_assert(!noexcept(std::ranges::rend(ntmrerr)));
-static_assert(!noexcept(std::ranges::crend(ntmrerr)));
+static_assert(!noexcept(xranges::rend(ntmrerr)));
+static_assert(!noexcept(xranges::crend(ntmrerr)));
 
 struct REndReturnsArrayRef {
-    auto rbegin() const noexcept -> int(&)[10];
-    auto rend() const noexcept -> int(&)[10];
+    auto rbegin() const noexcept -> int (&)[10];
+    auto rend() const noexcept -> int (&)[10];
+    auto begin() const noexcept -> int (&)[10];
+    auto end() const noexcept -> int (&)[10];
 } rerar;
-static_assert(noexcept(std::ranges::rend(rerar)));
-static_assert(noexcept(std::ranges::crend(rerar)));
+static_assert(noexcept(xranges::rend(rerar)));
+static_assert(noexcept(xranges::crend(rerar)));
 
 struct NoThrowBeginThrowingEnd {
-  int* begin() const noexcept;
-  int* end() const;
+    int* begin() const noexcept;
+    int* end() const;
 } ntbte;
-static_assert(noexcept(std::ranges::rend(ntbte)));
-static_assert(noexcept(std::ranges::crend(ntbte)));
+// make_reverse_iterator is not noexcept
+static_assert(!noexcept(xranges::rend(ntbte)));
+static_assert(!noexcept(xranges::crend(ntbte)));
 
 struct NoThrowEndThrowingBegin {
-  int* begin() const;
-  int* end() const noexcept;
+    int* begin() const;
+    int* end() const noexcept;
 } ntetb;
-static_assert(!noexcept(std::ranges::rend(ntetb)));
-static_assert(!noexcept(std::ranges::crend(ntetb)));
+static_assert(!noexcept(xranges::rend(ntetb)));
+static_assert(!noexcept(xranges::crend(ntetb)));
 
 // Test ADL-proofing.
 struct Incomplete;
-template<class T> struct Holder { T t; };
+template <class T>
+struct Holder {
+    T t;
+};
 static_assert(!std::is_invocable_v<RangeREndT, Holder<Incomplete>*>);
 static_assert(!std::is_invocable_v<RangeREndT, Holder<Incomplete>*&>);
 static_assert(!std::is_invocable_v<RangeCREndT, Holder<Incomplete>*>);
 static_assert(!std::is_invocable_v<RangeCREndT, Holder<Incomplete>*&>);
 
 int main(int, char**) {
-  static_assert(testReturnTypes());
+    static_assert(testReturnTypes());
 
-  testArray();
-  static_assert(testArray());
+    testArray();
+    static_assert(testArray());
 
-  testREndMember();
-  static_assert(testREndMember());
+    testREndMember();
+    static_assert(testREndMember());
 
-  testREndFunction();
-  static_assert(testREndFunction());
+    testREndFunction();
+    static_assert(testREndFunction());
 
-  testBeginEnd();
-  static_assert(testBeginEnd());
+    testBeginEnd();
+    static_assert(testBeginEnd());
 
-  return 0;
+    return 0;
 }

--- a/llvm/access/rend.pass.cpp
+++ b/llvm/access/rend.pass.cpp
@@ -583,7 +583,7 @@ static_assert(
         int*>);
 static_assert(
     std::same_as<std::invoke_result_t<RangeCREndT, MemberBeginAndRBegin&>,
-        int const*>);
+        rxx::basic_const_iterator<int*>>);
 
 constexpr bool testBeginEnd() {
     MemberBeginEnd a{};

--- a/llvm/access/rend.verify.cpp
+++ b/llvm/access/rend.verify.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::rend
+
+#include <ranges>
+
+struct NonBorrowedRange {
+  int* begin() const;
+  int* end() const;
+};
+static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
+
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::rend` is ill-formed.
+void test() {
+  std::ranges::rend(NonBorrowedRange());
+  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (std::ranges::)?__rend::__fn'}}}}
+  // expected-error@-2  {{attempt to use a deleted function}}
+}

--- a/llvm/access/rend.verify.cpp
+++ b/llvm/access/rend.verify.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/rend.verify.cpp
+++ b/llvm/access/rend.verify.cpp
@@ -11,19 +11,27 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::rend
+// rxx::ranges::rend
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
 
 struct NonBorrowedRange {
-  int* begin() const;
-  int* end() const;
+    int* begin() const;
+    int* end() const;
 };
 static_assert(!std::ranges::enable_borrowed_range<NonBorrowedRange>);
 
-// Verify that if the expression is an rvalue and `enable_borrowed_range` is false, `ranges::rend` is ill-formed.
+// Verify that if the expression is an rvalue and `enable_borrowed_range` is
+// false, `ranges::rend` is ill-formed.
 void test() {
-  std::ranges::rend(NonBorrowedRange());
-  // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (std::ranges::)?__rend::__fn'}}}}
-  // expected-error@-2  {{attempt to use a deleted function}}
+    xranges::rend(NonBorrowedRange());
+    // clang-format off
+    // expected-error-re@-1 {{{{call to deleted function call operator in type 'const (rxx::ranges::)?details::rend_t'}}}}
+    // expected-error@-2  {{attempt to use a deleted function}}
+    // clang-format on
 }

--- a/llvm/access/size.pass.cpp
+++ b/llvm/access/size.pass.cpp
@@ -1,0 +1,336 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::size
+
+#include <ranges>
+
+#include <cassert>
+#include "test_macros.h"
+#include "test_iterators.h"
+
+using RangeSizeT = decltype(std::ranges::size);
+
+static_assert(!std::is_invocable_v<RangeSizeT, int[]>);
+static_assert( std::is_invocable_v<RangeSizeT, int[1]>);
+static_assert( std::is_invocable_v<RangeSizeT, int (&&)[1]>);
+static_assert( std::is_invocable_v<RangeSizeT, int (&)[1]>);
+
+struct Incomplete;
+static_assert(!std::is_invocable_v<RangeSizeT, Incomplete[]>);
+static_assert(!std::is_invocable_v<RangeSizeT, Incomplete(&)[]>);
+static_assert(!std::is_invocable_v<RangeSizeT, Incomplete(&&)[]>);
+
+extern Incomplete array_of_incomplete[42];
+static_assert(std::ranges::size(array_of_incomplete) == 42);
+static_assert(std::ranges::size(std::move(array_of_incomplete)) == 42);
+static_assert(std::ranges::size(std::as_const(array_of_incomplete)) == 42);
+static_assert(std::ranges::size(static_cast<const Incomplete(&&)[42]>(array_of_incomplete)) == 42);
+
+struct SizeMember {
+  constexpr std::size_t size() { return 42; }
+};
+
+struct StaticSizeMember {
+  constexpr static std::size_t size() { return 42; }
+};
+
+static_assert(!std::is_invocable_v<RangeSizeT, const SizeMember>);
+
+struct SizeFunction {
+  friend constexpr std::size_t size(SizeFunction) { return 42; }
+};
+
+// Make sure the size member is preferred.
+struct SizeMemberAndFunction {
+  constexpr std::size_t size() { return 42; }
+  friend constexpr std::size_t size(SizeMemberAndFunction) { return 0; }
+};
+
+bool constexpr testArrayType() {
+  int a[4];
+  int b[1];
+  SizeMember c[4];
+  SizeFunction d[4];
+
+  assert(std::ranges::size(a) == 4);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(a)), std::size_t);
+  assert(std::ranges::size(b) == 1);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(b)), std::size_t);
+  assert(std::ranges::size(c) == 4);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(c)), std::size_t);
+  assert(std::ranges::size(d) == 4);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(d)), std::size_t);
+
+  return true;
+}
+
+struct SizeMemberConst {
+  constexpr std::size_t size() const { return 42; }
+};
+
+struct SizeMemberSigned {
+  constexpr long size() { return 42; }
+};
+
+bool constexpr testHasSizeMember() {
+  assert(std::ranges::size(SizeMember()) == 42);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(SizeMember())), std::size_t);
+
+  const SizeMemberConst sizeMemberConst;
+  assert(std::ranges::size(sizeMemberConst) == 42);
+
+  assert(std::ranges::size(SizeMemberAndFunction()) == 42);
+
+  assert(std::ranges::size(SizeMemberSigned()) == 42);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(SizeMemberSigned())), long);
+
+  assert(std::ranges::size(StaticSizeMember()) == 42);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(StaticSizeMember())), std::size_t);
+
+  return true;
+}
+
+struct MoveOnlySizeFunction {
+  MoveOnlySizeFunction() = default;
+  MoveOnlySizeFunction(MoveOnlySizeFunction &&) = default;
+  MoveOnlySizeFunction(MoveOnlySizeFunction const&) = delete;
+
+  friend constexpr std::size_t size(MoveOnlySizeFunction) { return 42; }
+};
+
+enum EnumSizeFunction {
+  a, b
+};
+
+constexpr std::size_t size(EnumSizeFunction) { return 42; }
+
+struct SizeFunctionConst {
+  friend constexpr std::size_t size(const SizeFunctionConst) { return 42; }
+};
+
+struct SizeFunctionRef {
+  friend constexpr std::size_t size(SizeFunctionRef&) { return 42; }
+};
+
+struct SizeFunctionConstRef {
+  friend constexpr std::size_t size(SizeFunctionConstRef const&) { return 42; }
+};
+
+struct SizeFunctionSigned {
+  friend constexpr long size(SizeFunctionSigned) { return 42; }
+};
+
+bool constexpr testHasSizeFunction() {
+  assert(std::ranges::size(SizeFunction()) == 42);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(SizeFunction())), std::size_t);
+  static_assert(!std::is_invocable_v<RangeSizeT, MoveOnlySizeFunction>);
+  assert(std::ranges::size(EnumSizeFunction()) == 42);
+  assert(std::ranges::size(SizeFunctionConst()) == 42);
+
+  SizeFunctionRef a;
+  assert(std::ranges::size(a) == 42);
+
+  const SizeFunctionConstRef b;
+  assert(std::ranges::size(b) == 42);
+
+  assert(std::ranges::size(SizeFunctionSigned()) == 42);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(SizeFunctionSigned())), long);
+
+  return true;
+}
+
+struct Empty { };
+static_assert(!std::is_invocable_v<RangeSizeT, Empty>);
+
+struct InvalidReturnTypeMember {
+  Empty size();
+};
+
+struct InvalidReturnTypeFunction {
+  friend Empty size(InvalidReturnTypeFunction);
+};
+
+struct Convertible {
+  operator std::size_t();
+};
+
+struct ConvertibleReturnTypeMember {
+  Convertible size();
+};
+
+struct ConvertibleReturnTypeFunction {
+  friend Convertible size(ConvertibleReturnTypeFunction);
+};
+
+struct BoolReturnTypeMember {
+  bool size() const;
+};
+
+struct BoolReturnTypeFunction {
+  friend bool size(BoolReturnTypeFunction const&);
+};
+
+static_assert(!std::is_invocable_v<RangeSizeT, InvalidReturnTypeMember>);
+static_assert(!std::is_invocable_v<RangeSizeT, InvalidReturnTypeFunction>);
+static_assert( std::is_invocable_v<RangeSizeT, InvalidReturnTypeMember (&)[4]>);
+static_assert( std::is_invocable_v<RangeSizeT, InvalidReturnTypeFunction (&)[4]>);
+static_assert(!std::is_invocable_v<RangeSizeT, ConvertibleReturnTypeMember>);
+static_assert(!std::is_invocable_v<RangeSizeT, ConvertibleReturnTypeFunction>);
+static_assert(!std::is_invocable_v<RangeSizeT, BoolReturnTypeMember const&>);
+static_assert(!std::is_invocable_v<RangeSizeT, BoolReturnTypeFunction const&>);
+
+struct SizeMemberDisabled {
+  std::size_t size() { return 42; }
+};
+
+template <>
+inline constexpr bool std::ranges::disable_sized_range<SizeMemberDisabled> = true;
+
+struct ImproperlyDisabledMember {
+  std::size_t size() const { return 42; }
+};
+
+// Intentionally disabling "const ConstSizeMemberDisabled". This doesn't disable anything
+// because T is always uncvrefed before being checked.
+template <>
+inline constexpr bool std::ranges::disable_sized_range<const ImproperlyDisabledMember> = true;
+
+struct SizeFunctionDisabled {
+  friend std::size_t size(SizeFunctionDisabled) { return 42; }
+};
+
+template <>
+inline constexpr bool std::ranges::disable_sized_range<SizeFunctionDisabled> = true;
+
+struct ImproperlyDisabledFunction {
+  friend std::size_t size(ImproperlyDisabledFunction const&) { return 42; }
+};
+
+template <>
+inline constexpr bool std::ranges::disable_sized_range<const ImproperlyDisabledFunction> = true;
+
+static_assert( std::is_invocable_v<RangeSizeT, ImproperlyDisabledMember&>);
+static_assert( std::is_invocable_v<RangeSizeT, const ImproperlyDisabledMember&>);
+static_assert(std::is_invocable_v<RangeSizeT,
+                                  ImproperlyDisabledFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
+static_assert( std::is_invocable_v<RangeSizeT, const ImproperlyDisabledFunction&>);
+
+// No begin end.
+struct HasMinusOperator {
+  friend constexpr std::size_t operator-(HasMinusOperator, HasMinusOperator) { return 2; }
+};
+static_assert(!std::is_invocable_v<RangeSizeT, HasMinusOperator>);
+
+struct HasMinusBeginEnd {
+  struct sentinel {
+    friend bool operator==(sentinel, forward_iterator<int*>);
+    friend constexpr std::ptrdiff_t operator-(const sentinel, const forward_iterator<int*>) { return 2; }
+    friend constexpr std::ptrdiff_t operator-(const forward_iterator<int*>, const sentinel) { return 2; }
+  };
+
+  friend constexpr forward_iterator<int*> begin(HasMinusBeginEnd) { return {}; }
+  friend constexpr sentinel end(HasMinusBeginEnd) { return {}; }
+};
+
+struct other_forward_iterator : forward_iterator<int*> { };
+
+struct InvalidMinusBeginEnd {
+  struct sentinel {
+    friend bool operator==(sentinel, other_forward_iterator);
+    friend constexpr std::ptrdiff_t operator-(const sentinel, const other_forward_iterator) { return 2; }
+    friend constexpr std::ptrdiff_t operator-(const other_forward_iterator, const sentinel) { return 2; }
+  };
+
+  friend constexpr other_forward_iterator begin(InvalidMinusBeginEnd) { return {}; }
+  friend constexpr sentinel end(InvalidMinusBeginEnd) { return {}; }
+};
+
+// short is integer-like, but it is not other_forward_iterator's difference_type.
+static_assert(!std::same_as<other_forward_iterator::difference_type, short>);
+static_assert(!std::is_invocable_v<RangeSizeT, InvalidMinusBeginEnd>);
+
+struct RandomAccessRange {
+  struct sentinel {
+    friend bool operator==(sentinel, random_access_iterator<int*>);
+    friend constexpr std::ptrdiff_t operator-(const sentinel, const random_access_iterator<int*>) { return 2; }
+    friend constexpr std::ptrdiff_t operator-(const random_access_iterator<int*>, const sentinel) { return 2; }
+  };
+
+  constexpr random_access_iterator<int*> begin() { return {}; }
+  constexpr sentinel end() { return {}; }
+};
+
+struct IntPtrBeginAndEnd {
+  int buff[8];
+  constexpr int* begin() { return buff; }
+  constexpr int* end() { return buff + 8; }
+};
+
+struct DisabledSizeRangeWithBeginEnd {
+  int buff[8];
+  constexpr int* begin() { return buff; }
+  constexpr int* end() { return buff + 8; }
+  constexpr std::size_t size() { return 1; }
+};
+
+template <>
+inline constexpr bool std::ranges::disable_sized_range<DisabledSizeRangeWithBeginEnd> = true;
+
+struct SizeBeginAndEndMembers {
+  int buff[8];
+  constexpr int* begin() { return buff; }
+  constexpr int* end() { return buff + 8; }
+  constexpr std::size_t size() { return 1; }
+};
+
+constexpr bool testRanges() {
+  HasMinusBeginEnd a;
+  assert(std::ranges::size(a) == 2);
+  // Ensure that this is converted to an *unsigned* type.
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(a)), std::size_t);
+
+  IntPtrBeginAndEnd b;
+  assert(std::ranges::size(b) == 8);
+
+  DisabledSizeRangeWithBeginEnd c;
+  assert(std::ranges::size(c) == 8);
+
+  RandomAccessRange d;
+  assert(std::ranges::size(d) == 2);
+  ASSERT_SAME_TYPE(decltype(std::ranges::size(d)), std::size_t);
+
+  SizeBeginAndEndMembers e;
+  assert(std::ranges::size(e) == 1);
+
+  return true;
+}
+
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(!std::is_invocable_v<RangeSizeT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeSizeT, Holder<Incomplete>*&>);
+
+int main(int, char**) {
+  testArrayType();
+  static_assert(testArrayType());
+
+  testHasSizeMember();
+  static_assert(testHasSizeMember());
+
+  testHasSizeFunction();
+  static_assert(testHasSizeFunction());
+
+  testRanges();
+  static_assert(testRanges());
+
+  return 0;
+}

--- a/llvm/access/size.pass.cpp
+++ b/llvm/access/size.pass.cpp
@@ -11,329 +11,372 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::size
+// xranges::size
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
 
 #include <cassert>
-#include "test_macros.h"
-#include "test_iterators.h"
 
-using RangeSizeT = decltype(std::ranges::size);
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
+
+using RangeSizeT = decltype(xranges::size);
 
 static_assert(!std::is_invocable_v<RangeSizeT, int[]>);
-static_assert( std::is_invocable_v<RangeSizeT, int[1]>);
-static_assert( std::is_invocable_v<RangeSizeT, int (&&)[1]>);
-static_assert( std::is_invocable_v<RangeSizeT, int (&)[1]>);
+static_assert(std::is_invocable_v<RangeSizeT, int[1]>);
+static_assert(std::is_invocable_v<RangeSizeT, int (&&)[1]>);
+static_assert(std::is_invocable_v<RangeSizeT, int (&)[1]>);
 
 struct Incomplete;
 static_assert(!std::is_invocable_v<RangeSizeT, Incomplete[]>);
-static_assert(!std::is_invocable_v<RangeSizeT, Incomplete(&)[]>);
-static_assert(!std::is_invocable_v<RangeSizeT, Incomplete(&&)[]>);
+static_assert(!std::is_invocable_v<RangeSizeT, Incomplete (&)[]>);
+static_assert(!std::is_invocable_v<RangeSizeT, Incomplete (&&)[]>);
 
 extern Incomplete array_of_incomplete[42];
-static_assert(std::ranges::size(array_of_incomplete) == 42);
-static_assert(std::ranges::size(std::move(array_of_incomplete)) == 42);
-static_assert(std::ranges::size(std::as_const(array_of_incomplete)) == 42);
-static_assert(std::ranges::size(static_cast<const Incomplete(&&)[42]>(array_of_incomplete)) == 42);
+static_assert(!std::is_invocable_v<RangeSizeT, Incomplete[42]>);
+static_assert(!std::is_invocable_v<RangeSizeT, Incomplete (&)[42]>);
+static_assert(!std::is_invocable_v<RangeSizeT, Incomplete (&&)[42]>);
 
 struct SizeMember {
-  constexpr std::size_t size() { return 42; }
+    constexpr std::size_t size() { return 42; }
 };
 
 struct StaticSizeMember {
-  constexpr static std::size_t size() { return 42; }
+    constexpr static std::size_t size() { return 42; }
 };
 
-static_assert(!std::is_invocable_v<RangeSizeT, const SizeMember>);
+static_assert(!std::is_invocable_v<RangeSizeT, SizeMember const>);
 
 struct SizeFunction {
-  friend constexpr std::size_t size(SizeFunction) { return 42; }
+    friend constexpr std::size_t size(SizeFunction) { return 42; }
 };
 
 // Make sure the size member is preferred.
 struct SizeMemberAndFunction {
-  constexpr std::size_t size() { return 42; }
-  friend constexpr std::size_t size(SizeMemberAndFunction) { return 0; }
+    constexpr std::size_t size() { return 42; }
+    friend constexpr std::size_t size(SizeMemberAndFunction) { return 0; }
 };
 
 bool constexpr testArrayType() {
-  int a[4];
-  int b[1];
-  SizeMember c[4];
-  SizeFunction d[4];
+    int a[4];
+    int b[1];
+    SizeMember c[4];
+    SizeFunction d[4];
 
-  assert(std::ranges::size(a) == 4);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(a)), std::size_t);
-  assert(std::ranges::size(b) == 1);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(b)), std::size_t);
-  assert(std::ranges::size(c) == 4);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(c)), std::size_t);
-  assert(std::ranges::size(d) == 4);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(d)), std::size_t);
+    assert(xranges::size(a) == 4);
+    ASSERT_SAME_TYPE(decltype(xranges::size(a)), std::size_t);
+    assert(xranges::size(b) == 1);
+    ASSERT_SAME_TYPE(decltype(xranges::size(b)), std::size_t);
+    assert(xranges::size(c) == 4);
+    ASSERT_SAME_TYPE(decltype(xranges::size(c)), std::size_t);
+    assert(xranges::size(d) == 4);
+    ASSERT_SAME_TYPE(decltype(xranges::size(d)), std::size_t);
 
-  return true;
+    return true;
 }
 
 struct SizeMemberConst {
-  constexpr std::size_t size() const { return 42; }
+    constexpr std::size_t size() const { return 42; }
 };
 
 struct SizeMemberSigned {
-  constexpr long size() { return 42; }
+    constexpr long size() { return 42; }
 };
 
 bool constexpr testHasSizeMember() {
-  assert(std::ranges::size(SizeMember()) == 42);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(SizeMember())), std::size_t);
+    assert(xranges::size(SizeMember()) == 42);
+    ASSERT_SAME_TYPE(decltype(xranges::size(SizeMember())), std::size_t);
 
-  const SizeMemberConst sizeMemberConst;
-  assert(std::ranges::size(sizeMemberConst) == 42);
+    SizeMemberConst const sizeMemberConst;
+    assert(xranges::size(sizeMemberConst) == 42);
 
-  assert(std::ranges::size(SizeMemberAndFunction()) == 42);
+    assert(xranges::size(SizeMemberAndFunction()) == 42);
 
-  assert(std::ranges::size(SizeMemberSigned()) == 42);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(SizeMemberSigned())), long);
+    assert(xranges::size(SizeMemberSigned()) == 42);
+    ASSERT_SAME_TYPE(decltype(xranges::size(SizeMemberSigned())), long);
 
-  assert(std::ranges::size(StaticSizeMember()) == 42);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(StaticSizeMember())), std::size_t);
+    assert(xranges::size(StaticSizeMember()) == 42);
+    ASSERT_SAME_TYPE(decltype(xranges::size(StaticSizeMember())), std::size_t);
 
-  return true;
+    return true;
 }
 
 struct MoveOnlySizeFunction {
-  MoveOnlySizeFunction() = default;
-  MoveOnlySizeFunction(MoveOnlySizeFunction &&) = default;
-  MoveOnlySizeFunction(MoveOnlySizeFunction const&) = delete;
+    MoveOnlySizeFunction() = default;
+    MoveOnlySizeFunction(MoveOnlySizeFunction&&) = default;
+    MoveOnlySizeFunction(MoveOnlySizeFunction const&) = delete;
 
-  friend constexpr std::size_t size(MoveOnlySizeFunction) { return 42; }
+    friend constexpr std::size_t size(MoveOnlySizeFunction) { return 42; }
 };
 
 enum EnumSizeFunction {
-  a, b
+    a,
+    b
 };
 
-constexpr std::size_t size(EnumSizeFunction) { return 42; }
+constexpr std::size_t size(EnumSizeFunction) {
+    return 42;
+}
 
 struct SizeFunctionConst {
-  friend constexpr std::size_t size(const SizeFunctionConst) { return 42; }
+    friend constexpr std::size_t size(SizeFunctionConst const) { return 42; }
 };
 
 struct SizeFunctionRef {
-  friend constexpr std::size_t size(SizeFunctionRef&) { return 42; }
+    friend constexpr std::size_t size(SizeFunctionRef&) { return 42; }
 };
 
 struct SizeFunctionConstRef {
-  friend constexpr std::size_t size(SizeFunctionConstRef const&) { return 42; }
+    friend constexpr std::size_t size(SizeFunctionConstRef const&) {
+        return 42;
+    }
 };
 
 struct SizeFunctionSigned {
-  friend constexpr long size(SizeFunctionSigned) { return 42; }
+    friend constexpr long size(SizeFunctionSigned) { return 42; }
 };
 
 bool constexpr testHasSizeFunction() {
-  assert(std::ranges::size(SizeFunction()) == 42);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(SizeFunction())), std::size_t);
-  static_assert(!std::is_invocable_v<RangeSizeT, MoveOnlySizeFunction>);
-  assert(std::ranges::size(EnumSizeFunction()) == 42);
-  assert(std::ranges::size(SizeFunctionConst()) == 42);
+    assert(xranges::size(SizeFunction()) == 42);
+    ASSERT_SAME_TYPE(decltype(xranges::size(SizeFunction())), std::size_t);
+    static_assert(!std::is_invocable_v<RangeSizeT, MoveOnlySizeFunction>);
+    assert(xranges::size(EnumSizeFunction()) == 42);
+    assert(xranges::size(SizeFunctionConst()) == 42);
 
-  SizeFunctionRef a;
-  assert(std::ranges::size(a) == 42);
+    SizeFunctionRef a;
+    assert(xranges::size(a) == 42);
 
-  const SizeFunctionConstRef b;
-  assert(std::ranges::size(b) == 42);
+    SizeFunctionConstRef const b;
+    assert(xranges::size(b) == 42);
 
-  assert(std::ranges::size(SizeFunctionSigned()) == 42);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(SizeFunctionSigned())), long);
+    assert(xranges::size(SizeFunctionSigned()) == 42);
+    ASSERT_SAME_TYPE(decltype(xranges::size(SizeFunctionSigned())), long);
 
-  return true;
+    return true;
 }
 
-struct Empty { };
+struct Empty {};
 static_assert(!std::is_invocable_v<RangeSizeT, Empty>);
 
 struct InvalidReturnTypeMember {
-  Empty size();
+    Empty size();
 };
 
 struct InvalidReturnTypeFunction {
-  friend Empty size(InvalidReturnTypeFunction);
+    friend Empty size(InvalidReturnTypeFunction);
 };
 
 struct Convertible {
-  operator std::size_t();
+    operator std::size_t();
 };
 
 struct ConvertibleReturnTypeMember {
-  Convertible size();
+    Convertible size();
 };
 
 struct ConvertibleReturnTypeFunction {
-  friend Convertible size(ConvertibleReturnTypeFunction);
+    friend Convertible size(ConvertibleReturnTypeFunction);
 };
 
 struct BoolReturnTypeMember {
-  bool size() const;
+    bool size() const;
 };
 
 struct BoolReturnTypeFunction {
-  friend bool size(BoolReturnTypeFunction const&);
+    friend bool size(BoolReturnTypeFunction const&);
 };
 
 static_assert(!std::is_invocable_v<RangeSizeT, InvalidReturnTypeMember>);
 static_assert(!std::is_invocable_v<RangeSizeT, InvalidReturnTypeFunction>);
-static_assert( std::is_invocable_v<RangeSizeT, InvalidReturnTypeMember (&)[4]>);
-static_assert( std::is_invocable_v<RangeSizeT, InvalidReturnTypeFunction (&)[4]>);
+static_assert(std::is_invocable_v<RangeSizeT, InvalidReturnTypeMember (&)[4]>);
+static_assert(
+    std::is_invocable_v<RangeSizeT, InvalidReturnTypeFunction (&)[4]>);
 static_assert(!std::is_invocable_v<RangeSizeT, ConvertibleReturnTypeMember>);
 static_assert(!std::is_invocable_v<RangeSizeT, ConvertibleReturnTypeFunction>);
 static_assert(!std::is_invocable_v<RangeSizeT, BoolReturnTypeMember const&>);
 static_assert(!std::is_invocable_v<RangeSizeT, BoolReturnTypeFunction const&>);
 
 struct SizeMemberDisabled {
-  std::size_t size() { return 42; }
+    std::size_t size() { return 42; }
 };
 
 template <>
-inline constexpr bool std::ranges::disable_sized_range<SizeMemberDisabled> = true;
+inline constexpr bool std::ranges::disable_sized_range<SizeMemberDisabled> =
+    true;
 
 struct ImproperlyDisabledMember {
-  std::size_t size() const { return 42; }
+    std::size_t size() const { return 42; }
 };
 
-// Intentionally disabling "const ConstSizeMemberDisabled". This doesn't disable anything
-// because T is always uncvrefed before being checked.
+// Intentionally disabling "const ConstSizeMemberDisabled". This doesn't disable
+// anything because T is always uncvrefed before being checked.
 template <>
-inline constexpr bool std::ranges::disable_sized_range<const ImproperlyDisabledMember> = true;
+inline constexpr bool
+    std::ranges::disable_sized_range<ImproperlyDisabledMember const> = true;
 
 struct SizeFunctionDisabled {
-  friend std::size_t size(SizeFunctionDisabled) { return 42; }
+    friend std::size_t size(SizeFunctionDisabled) { return 42; }
 };
 
 template <>
-inline constexpr bool std::ranges::disable_sized_range<SizeFunctionDisabled> = true;
+inline constexpr bool std::ranges::disable_sized_range<SizeFunctionDisabled> =
+    true;
 
 struct ImproperlyDisabledFunction {
-  friend std::size_t size(ImproperlyDisabledFunction const&) { return 42; }
+    friend std::size_t size(ImproperlyDisabledFunction const&) { return 42; }
 };
 
 template <>
-inline constexpr bool std::ranges::disable_sized_range<const ImproperlyDisabledFunction> = true;
+inline constexpr bool
+    std::ranges::disable_sized_range<ImproperlyDisabledFunction const> = true;
 
-static_assert( std::is_invocable_v<RangeSizeT, ImproperlyDisabledMember&>);
-static_assert( std::is_invocable_v<RangeSizeT, const ImproperlyDisabledMember&>);
+static_assert(std::is_invocable_v<RangeSizeT, ImproperlyDisabledMember&>);
+static_assert(std::is_invocable_v<RangeSizeT, ImproperlyDisabledMember const&>);
 static_assert(std::is_invocable_v<RangeSizeT,
-                                  ImproperlyDisabledFunction&>); // Ill-formed before P2602R2 Poison Pills are Too Toxic
-static_assert( std::is_invocable_v<RangeSizeT, const ImproperlyDisabledFunction&>);
+    ImproperlyDisabledFunction&>); // Ill-formed before P2602R2 Poison Pills are
+                                   // Too Toxic
+static_assert(
+    std::is_invocable_v<RangeSizeT, ImproperlyDisabledFunction const&>);
 
 // No begin end.
 struct HasMinusOperator {
-  friend constexpr std::size_t operator-(HasMinusOperator, HasMinusOperator) { return 2; }
+    friend constexpr std::size_t operator-(HasMinusOperator, HasMinusOperator) {
+        return 2;
+    }
 };
 static_assert(!std::is_invocable_v<RangeSizeT, HasMinusOperator>);
 
 struct HasMinusBeginEnd {
-  struct sentinel {
-    friend bool operator==(sentinel, forward_iterator<int*>);
-    friend constexpr std::ptrdiff_t operator-(const sentinel, const forward_iterator<int*>) { return 2; }
-    friend constexpr std::ptrdiff_t operator-(const forward_iterator<int*>, const sentinel) { return 2; }
-  };
+    struct sentinel {
+        friend bool operator==(sentinel, forward_iterator<int*>);
+        friend constexpr std::ptrdiff_t operator-(
+            sentinel const, forward_iterator<int*> const) {
+            return 2;
+        }
+        friend constexpr std::ptrdiff_t operator-(
+            forward_iterator<int*> const, sentinel const) {
+            return 2;
+        }
+    };
 
-  friend constexpr forward_iterator<int*> begin(HasMinusBeginEnd) { return {}; }
-  friend constexpr sentinel end(HasMinusBeginEnd) { return {}; }
+    friend constexpr forward_iterator<int*> begin(HasMinusBeginEnd) {
+        return {};
+    }
+    friend constexpr sentinel end(HasMinusBeginEnd) { return {}; }
 };
 
-struct other_forward_iterator : forward_iterator<int*> { };
+struct other_forward_iterator : forward_iterator<int*> {};
 
 struct InvalidMinusBeginEnd {
-  struct sentinel {
-    friend bool operator==(sentinel, other_forward_iterator);
-    friend constexpr std::ptrdiff_t operator-(const sentinel, const other_forward_iterator) { return 2; }
-    friend constexpr std::ptrdiff_t operator-(const other_forward_iterator, const sentinel) { return 2; }
-  };
+    struct sentinel {
+        friend bool operator==(sentinel, other_forward_iterator);
+        friend constexpr std::ptrdiff_t operator-(
+            sentinel const, other_forward_iterator const) {
+            return 2;
+        }
+        friend constexpr std::ptrdiff_t operator-(
+            other_forward_iterator const, sentinel const) {
+            return 2;
+        }
+    };
 
-  friend constexpr other_forward_iterator begin(InvalidMinusBeginEnd) { return {}; }
-  friend constexpr sentinel end(InvalidMinusBeginEnd) { return {}; }
+    friend constexpr other_forward_iterator begin(InvalidMinusBeginEnd) {
+        return {};
+    }
+    friend constexpr sentinel end(InvalidMinusBeginEnd) { return {}; }
 };
 
-// short is integer-like, but it is not other_forward_iterator's difference_type.
+// short is integer-like, but it is not other_forward_iterator's
+// difference_type.
 static_assert(!std::same_as<other_forward_iterator::difference_type, short>);
 static_assert(!std::is_invocable_v<RangeSizeT, InvalidMinusBeginEnd>);
 
 struct RandomAccessRange {
-  struct sentinel {
-    friend bool operator==(sentinel, random_access_iterator<int*>);
-    friend constexpr std::ptrdiff_t operator-(const sentinel, const random_access_iterator<int*>) { return 2; }
-    friend constexpr std::ptrdiff_t operator-(const random_access_iterator<int*>, const sentinel) { return 2; }
-  };
+    struct sentinel {
+        friend bool operator==(sentinel, random_access_iterator<int*>);
+        friend constexpr std::ptrdiff_t operator-(
+            sentinel const, random_access_iterator<int*> const) {
+            return 2;
+        }
+        friend constexpr std::ptrdiff_t operator-(
+            random_access_iterator<int*> const, sentinel const) {
+            return 2;
+        }
+    };
 
-  constexpr random_access_iterator<int*> begin() { return {}; }
-  constexpr sentinel end() { return {}; }
+    constexpr random_access_iterator<int*> begin() { return {}; }
+    constexpr sentinel end() { return {}; }
 };
 
 struct IntPtrBeginAndEnd {
-  int buff[8];
-  constexpr int* begin() { return buff; }
-  constexpr int* end() { return buff + 8; }
+    int buff[8];
+    constexpr int* begin() { return buff; }
+    constexpr int* end() { return buff + 8; }
 };
 
 struct DisabledSizeRangeWithBeginEnd {
-  int buff[8];
-  constexpr int* begin() { return buff; }
-  constexpr int* end() { return buff + 8; }
-  constexpr std::size_t size() { return 1; }
+    int buff[8];
+    constexpr int* begin() { return buff; }
+    constexpr int* end() { return buff + 8; }
+    constexpr std::size_t size() { return 1; }
 };
 
 template <>
-inline constexpr bool std::ranges::disable_sized_range<DisabledSizeRangeWithBeginEnd> = true;
+inline constexpr bool
+    std::ranges::disable_sized_range<DisabledSizeRangeWithBeginEnd> = true;
 
 struct SizeBeginAndEndMembers {
-  int buff[8];
-  constexpr int* begin() { return buff; }
-  constexpr int* end() { return buff + 8; }
-  constexpr std::size_t size() { return 1; }
+    int buff[8];
+    constexpr int* begin() { return buff; }
+    constexpr int* end() { return buff + 8; }
+    constexpr std::size_t size() { return 1; }
 };
 
 constexpr bool testRanges() {
-  HasMinusBeginEnd a;
-  assert(std::ranges::size(a) == 2);
-  // Ensure that this is converted to an *unsigned* type.
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(a)), std::size_t);
+    HasMinusBeginEnd a;
+    assert(xranges::size(a) == 2);
+    // Ensure that this is converted to an *unsigned* type.
+    ASSERT_SAME_TYPE(decltype(xranges::size(a)), std::size_t);
 
-  IntPtrBeginAndEnd b;
-  assert(std::ranges::size(b) == 8);
+    IntPtrBeginAndEnd b;
+    assert(xranges::size(b) == 8);
 
-  DisabledSizeRangeWithBeginEnd c;
-  assert(std::ranges::size(c) == 8);
+    DisabledSizeRangeWithBeginEnd c;
+    assert(xranges::size(c) == 8);
 
-  RandomAccessRange d;
-  assert(std::ranges::size(d) == 2);
-  ASSERT_SAME_TYPE(decltype(std::ranges::size(d)), std::size_t);
+    RandomAccessRange d;
+    assert(xranges::size(d) == 2);
+    ASSERT_SAME_TYPE(decltype(xranges::size(d)), std::size_t);
 
-  SizeBeginAndEndMembers e;
-  assert(std::ranges::size(e) == 1);
+    SizeBeginAndEndMembers e;
+    assert(xranges::size(e) == 1);
 
-  return true;
+    return true;
 }
 
 // Test ADL-proofing.
 struct Incomplete;
-template<class T> struct Holder { T t; };
+template <class T>
+struct Holder {
+    T t;
+};
 static_assert(!std::is_invocable_v<RangeSizeT, Holder<Incomplete>*>);
 static_assert(!std::is_invocable_v<RangeSizeT, Holder<Incomplete>*&>);
 
 int main(int, char**) {
-  testArrayType();
-  static_assert(testArrayType());
+    testArrayType();
+    static_assert(testArrayType());
 
-  testHasSizeMember();
-  static_assert(testHasSizeMember());
+    testHasSizeMember();
+    static_assert(testHasSizeMember());
 
-  testHasSizeFunction();
-  static_assert(testHasSizeFunction());
+    testHasSizeFunction();
+    static_assert(testHasSizeFunction());
 
-  testRanges();
-  static_assert(testRanges());
+    testRanges();
+    static_assert(testRanges());
 
-  return 0;
+    return 0;
 }

--- a/llvm/access/size.pass.cpp
+++ b/llvm/access/size.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/size.verify.cpp
+++ b/llvm/access/size.verify.cpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::size
+
+#include <ranges>
+
+extern int arr[];
+
+// Verify that for an array of unknown bound `ranges::size` is ill-formed.
+void test() {
+  std::ranges::size(arr);
+  // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?__size::__fn'}}}}
+}

--- a/llvm/access/size.verify.cpp
+++ b/llvm/access/size.verify.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/size.verify.cpp
+++ b/llvm/access/size.verify.cpp
@@ -11,14 +11,21 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::size
+// rxx::ranges::size
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
 
 extern int arr[];
 
 // Verify that for an array of unknown bound `ranges::size` is ill-formed.
 void test() {
-  std::ranges::size(arr);
-  // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?__size::__fn'}}}}
+    xranges::size(arr);
+    // clang-format off
+    // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?details::size_func_t'}}}}
+    // clang-format on
 }

--- a/llvm/access/size.verify.cpp
+++ b/llvm/access/size.verify.cpp
@@ -26,6 +26,6 @@ extern int arr[];
 void test() {
     xranges::size(arr);
     // clang-format off
-    // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?details::size_func_t'}}}}
+    // expected-error-re@-1 {{{{no matching function for call to object of type 'const (rxx::ranges::)?details::size_func_t'}}}}
     // clang-format on
 }

--- a/llvm/access/ssize.pass.cpp
+++ b/llvm/access/ssize.pass.cpp
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::ssize
+
+#include <ranges>
+
+#include <cassert>
+#include "test_macros.h"
+#include "test_iterators.h"
+
+using RangeSSizeT = decltype(std::ranges::ssize);
+
+static_assert(!std::is_invocable_v<RangeSSizeT, int[]>);
+static_assert( std::is_invocable_v<RangeSSizeT, int[1]>);
+static_assert( std::is_invocable_v<RangeSSizeT, int (&&)[1]>);
+static_assert( std::is_invocable_v<RangeSSizeT, int (&)[1]>);
+
+struct SizeMember {
+  constexpr std::size_t size() { return 42; }
+};
+static_assert(!std::is_invocable_v<decltype(std::ranges::ssize), const SizeMember&>);
+
+struct SizeFunction {
+  friend constexpr std::size_t size(SizeFunction) { return 42; }
+};
+
+struct SizeFunctionSigned {
+  friend constexpr std::ptrdiff_t size(SizeFunctionSigned) { return 42; }
+};
+
+struct SizedSentinelRange {
+  int data_[2] = {};
+  constexpr int *begin() { return data_; }
+  constexpr auto end() { return sized_sentinel<int*>(data_ + 2); }
+};
+
+struct ShortUnsignedReturnType {
+  constexpr unsigned short size() { return 42; }
+};
+
+// size_t changes depending on the platform.
+using SignedSizeT = std::make_signed_t<std::size_t>;
+
+constexpr bool test() {
+  int a[4];
+
+  assert(std::ranges::ssize(a) == 4);
+  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(a)), SignedSizeT);
+
+  assert(std::ranges::ssize(SizeMember()) == 42);
+  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(SizeMember())), SignedSizeT);
+
+  assert(std::ranges::ssize(SizeFunction()) == 42);
+  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(SizeFunction())), SignedSizeT);
+
+  assert(std::ranges::ssize(SizeFunctionSigned()) == 42);
+  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(SizeFunctionSigned())), std::ptrdiff_t);
+
+  SizedSentinelRange b;
+  assert(std::ranges::ssize(b) == 2);
+  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(b)), std::ptrdiff_t);
+
+  // This gets converted to ptrdiff_t because it's wider.
+  ShortUnsignedReturnType c;
+  assert(std::ranges::ssize(c) == 42);
+  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(c)), std::ptrdiff_t);
+
+  return true;
+}
+
+// Test ADL-proofing.
+struct Incomplete;
+template<class T> struct Holder { T t; };
+static_assert(!std::is_invocable_v<RangeSSizeT, Holder<Incomplete>*>);
+static_assert(!std::is_invocable_v<RangeSSizeT, Holder<Incomplete>*&>);
+
+int main(int, char**) {
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/llvm/access/ssize.pass.cpp
+++ b/llvm/access/ssize.pass.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/ssize.pass.cpp
+++ b/llvm/access/ssize.pass.cpp
@@ -11,83 +11,88 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::ssize
+// xranges::ssize
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
 
 #include <cassert>
-#include "test_macros.h"
-#include "test_iterators.h"
 
-using RangeSSizeT = decltype(std::ranges::ssize);
+using RangeSSizeT = decltype(xranges::ssize);
 
 static_assert(!std::is_invocable_v<RangeSSizeT, int[]>);
-static_assert( std::is_invocable_v<RangeSSizeT, int[1]>);
-static_assert( std::is_invocable_v<RangeSSizeT, int (&&)[1]>);
-static_assert( std::is_invocable_v<RangeSSizeT, int (&)[1]>);
+static_assert(std::is_invocable_v<RangeSSizeT, int[1]>);
+static_assert(std::is_invocable_v<RangeSSizeT, int (&&)[1]>);
+static_assert(std::is_invocable_v<RangeSSizeT, int (&)[1]>);
 
 struct SizeMember {
-  constexpr std::size_t size() { return 42; }
+    constexpr std::size_t size() { return 42; }
 };
-static_assert(!std::is_invocable_v<decltype(std::ranges::ssize), const SizeMember&>);
+static_assert(
+    !std::is_invocable_v<decltype(xranges::ssize), SizeMember const&>);
 
 struct SizeFunction {
-  friend constexpr std::size_t size(SizeFunction) { return 42; }
+    friend constexpr std::size_t size(SizeFunction) { return 42; }
 };
 
 struct SizeFunctionSigned {
-  friend constexpr std::ptrdiff_t size(SizeFunctionSigned) { return 42; }
+    friend constexpr std::ptrdiff_t size(SizeFunctionSigned) { return 42; }
 };
 
 struct SizedSentinelRange {
-  int data_[2] = {};
-  constexpr int *begin() { return data_; }
-  constexpr auto end() { return sized_sentinel<int*>(data_ + 2); }
+    int data_[2] = {};
+    constexpr int* begin() { return data_; }
+    constexpr auto end() { return sized_sentinel<int*>(data_ + 2); }
 };
 
 struct ShortUnsignedReturnType {
-  constexpr unsigned short size() { return 42; }
+    constexpr unsigned short size() { return 42; }
 };
 
 // size_t changes depending on the platform.
 using SignedSizeT = std::make_signed_t<std::size_t>;
 
 constexpr bool test() {
-  int a[4];
+    int a[4];
 
-  assert(std::ranges::ssize(a) == 4);
-  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(a)), SignedSizeT);
+    assert(xranges::ssize(a) == 4);
+    ASSERT_SAME_TYPE(decltype(xranges::ssize(a)), SignedSizeT);
 
-  assert(std::ranges::ssize(SizeMember()) == 42);
-  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(SizeMember())), SignedSizeT);
+    assert(xranges::ssize(SizeMember()) == 42);
+    ASSERT_SAME_TYPE(decltype(xranges::ssize(SizeMember())), SignedSizeT);
 
-  assert(std::ranges::ssize(SizeFunction()) == 42);
-  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(SizeFunction())), SignedSizeT);
+    assert(xranges::ssize(SizeFunction()) == 42);
+    ASSERT_SAME_TYPE(decltype(xranges::ssize(SizeFunction())), SignedSizeT);
 
-  assert(std::ranges::ssize(SizeFunctionSigned()) == 42);
-  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(SizeFunctionSigned())), std::ptrdiff_t);
+    assert(xranges::ssize(SizeFunctionSigned()) == 42);
+    ASSERT_SAME_TYPE(
+        decltype(xranges::ssize(SizeFunctionSigned())), std::ptrdiff_t);
 
-  SizedSentinelRange b;
-  assert(std::ranges::ssize(b) == 2);
-  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(b)), std::ptrdiff_t);
+    SizedSentinelRange b;
+    assert(xranges::ssize(b) == 2);
+    ASSERT_SAME_TYPE(decltype(xranges::ssize(b)), std::ptrdiff_t);
 
-  // This gets converted to ptrdiff_t because it's wider.
-  ShortUnsignedReturnType c;
-  assert(std::ranges::ssize(c) == 42);
-  ASSERT_SAME_TYPE(decltype(std::ranges::ssize(c)), std::ptrdiff_t);
+    // This gets converted to ptrdiff_t because it's wider.
+    ShortUnsignedReturnType c;
+    assert(xranges::ssize(c) == 42);
+    ASSERT_SAME_TYPE(decltype(xranges::ssize(c)), std::ptrdiff_t);
 
-  return true;
+    return true;
 }
 
 // Test ADL-proofing.
 struct Incomplete;
-template<class T> struct Holder { T t; };
+template <class T>
+struct Holder {
+    T t;
+};
 static_assert(!std::is_invocable_v<RangeSSizeT, Holder<Incomplete>*>);
 static_assert(!std::is_invocable_v<RangeSSizeT, Holder<Incomplete>*&>);
 
 int main(int, char**) {
-  test();
-  static_assert(test());
+    test();
+    static_assert(test());
 
-  return 0;
+    return 0;
 }

--- a/llvm/access/ssize.verify.cpp
+++ b/llvm/access/ssize.verify.cpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// std::ranges::size
+
+#include <ranges>
+
+extern int arr[];
+
+// Verify that for an array of unknown bound `ranges::ssize` is ill-formed.
+void test() {
+  std::ranges::ssize(arr);
+  // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?__ssize::__fn'}}}}
+}

--- a/llvm/access/ssize.verify.cpp
+++ b/llvm/access/ssize.verify.cpp
@@ -1,3 +1,6 @@
+// Copyright 2025 Bryan Wong
+// Adapted from LLVM testsuite
+
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/llvm/access/ssize.verify.cpp
+++ b/llvm/access/ssize.verify.cpp
@@ -26,6 +26,6 @@ extern int arr[];
 void test() {
     xranges::ssize(arr);
     // clang-format off
-    // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?details::ssize_t'}}}}
+    // expected-error-re@-1 {{{{no matching function for call to object of type 'const (rxx::ranges::)?details::ssize_t'}}}}
     // clang-format on
 }

--- a/llvm/access/ssize.verify.cpp
+++ b/llvm/access/ssize.verify.cpp
@@ -11,14 +11,21 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// std::ranges::size
+// rxx::ranges::size
 
-#include <ranges>
+#include "../static_asserts.h"
+#include "../test_iterators.h"
+#include "rxx/access.h"
+
+namespace xranges = rxx::ranges;
+namespace xviews = rxx::views;
 
 extern int arr[];
 
 // Verify that for an array of unknown bound `ranges::ssize` is ill-formed.
 void test() {
-  std::ranges::ssize(arr);
-  // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?__ssize::__fn'}}}}
+    xranges::ssize(arr);
+    // clang-format off
+    // expected-error-re@-1 {{{{no matching function for call to object of type 'const (std::ranges::)?details::ssize_t'}}}}
+    // clang-format on
 }


### PR DESCRIPTION
* Add tests from the llvm test suite for access CPOs
* LLVM Tests for CPOs related to `const`, e.g. cbegin, cend, etc. require changes since new behaviour is added in C++23